### PR TITLE
Refactor `OcflRepositoryGateway.stage_object_files` (DOROP-31)

### DIFF
--- a/gateway/exceptions.py
+++ b/gateway/exceptions.py
@@ -12,6 +12,3 @@ class ObjectDoesNotExistError(RepositoryGatewayError):
 
 class StagedObjectAlreadyExistsError(RepositoryGatewayError):
     pass
-
-class StagedObjectDoesNotExistError(RepositoryGatewayError):
-    pass

--- a/gateway/ocfl_repository_gateway.py
+++ b/gateway/ocfl_repository_gateway.py
@@ -61,7 +61,7 @@ class OcflRepositoryGateway(RepositoryGateway):
             raise RepositoryGatewayError() from e
 
     def stage_object_files(self, id: str, source_package: Package) -> None:
-        if not self.has_object(id) and not self.has_staged_object(id):
+        if not self.has_object(id) and not self._has_staged_object(id):
             raise ObjectDoesNotExistError(f"No object or staged object found for id {id}")
 
         package_root = source_package.get_root_path()
@@ -106,7 +106,7 @@ class OcflRepositoryGateway(RepositoryGateway):
                 return False
             raise RepositoryGatewayError() from e
 
-    def has_staged_object(self, id: str):
+    def _has_staged_object(self, id: str):
         args = ["rocfl", "-r", str(self.storage_path), "status", id]
         try:
             subprocess.run(args, check=True, capture_output=True)
@@ -118,7 +118,7 @@ class OcflRepositoryGateway(RepositoryGateway):
             raise RepositoryGatewayError() from e
 
     def get_object_files(self, id: str, include_staged: bool = False) -> list[ObjectFile]:
-        has_staged_object = self.has_staged_object(id)
+        has_staged_object = self._has_staged_object(id)
         if not self.has_object(id) and not has_staged_object:
             raise ObjectDoesNotExistError(f"No object or staged object found for id {id}")
 

--- a/gateway/ocfl_repository_gateway.py
+++ b/gateway/ocfl_repository_gateway.py
@@ -29,8 +29,8 @@ class OcflRepositoryGateway(RepositoryGateway):
         self.storage_layout: StorageLayout = storage_layout
 
     def create_repository(self) -> None:
-        args = [
-            "rocfl", "-r", str(self.storage_path), "init",
+        args: list[str | Path] = [
+            "rocfl", "-r", self.storage_path, "init",
             "-l", self.storage_layout.value
         ]
         try:
@@ -39,7 +39,7 @@ class OcflRepositoryGateway(RepositoryGateway):
             raise RepositoryGatewayError() from e
 
     def create_staged_object(self, id: str) -> None:
-        args = ["rocfl", "-r", str(self.storage_path), "new", id]
+        args: list[str | Path] = ["rocfl", "-r", self.storage_path, "new", id]
         try:
             subprocess.run(args, check=True, capture_output=True)
         except CalledProcessError as e:
@@ -51,12 +51,12 @@ class OcflRepositoryGateway(RepositoryGateway):
             raise RepositoryGatewayError() from e
 
     def _stage_object_file(self, id, source_path: Path, dest_path: Path) -> None:
-        command = [
-            "rocfl", "-r", str(self.storage_path),
-            "cp", "-r", id, str(source_path.absolute()), "--", str(dest_path)
+        args: list[str | Path] = [
+            "rocfl", "-r", self.storage_path,
+            "cp", "-r", id, source_path.absolute(), "--", dest_path
         ]
         try:
-            subprocess.run(command, check=True, capture_output=True)
+            subprocess.run(args, check=True, capture_output=True)
         except CalledProcessError as e:
             raise RepositoryGatewayError() from e
 
@@ -75,8 +75,8 @@ class OcflRepositoryGateway(RepositoryGateway):
         coordinator: Coordinator,
         message: str
     ) -> None:
-        args = [
-            "rocfl", "-r", str(self.storage_path), "commit", id,
+        args: list[str | Path] = [
+            "rocfl", "-r", self.storage_path, "commit", id,
             "-n", coordinator.username, "-a", f"mailto:{coordinator.email}",
             "-m", message
         ]
@@ -89,14 +89,14 @@ class OcflRepositoryGateway(RepositoryGateway):
             raise RepositoryGatewayError() from e
 
     def purge_object(self, id: str) -> None:
-        args = ["rocfl", "-r", str(self.storage_path), "purge", "-f", id]
+        args: list[str | Path] = ["rocfl", "-r", self.storage_path, "purge", "-f", id]
         try:
             subprocess.run(args, check=True, capture_output=True)
         except CalledProcessError as e:
             raise RepositoryGatewayError() from e
 
     def has_object(self, id: str) -> bool:
-        args = ["rocfl", "-r", str(self.storage_path), "info", id]
+        args: list[str | Path] = ["rocfl", "-r", self.storage_path, "info", id]
         try:
             subprocess.run(args, check=True, capture_output=True)
             return True
@@ -107,7 +107,7 @@ class OcflRepositoryGateway(RepositoryGateway):
             raise RepositoryGatewayError() from e
 
     def _has_staged_object(self, id: str):
-        args = ["rocfl", "-r", str(self.storage_path), "status", id]
+        args: list[str | Path] = ["rocfl", "-r", self.storage_path, "status", id]
         try:
             subprocess.run(args, check=True, capture_output=True)
             return True
@@ -123,7 +123,7 @@ class OcflRepositoryGateway(RepositoryGateway):
             raise ObjectDoesNotExistError(f"No object or staged object found for id {id}")
 
         flags = "-ptS" if include_staged and has_staged_object else "-pt"
-        args = ["rocfl", "-r", str(self.storage_path), "ls", flags, id]
+        args: list[str | Path] = ["rocfl", "-r", self.storage_path, "ls", flags, id]
         try:
             result = subprocess.run(args, check=True, capture_output=True)
         except CalledProcessError as e:

--- a/gateway/package.py
+++ b/gateway/package.py
@@ -28,10 +28,3 @@ class Package:
                 full_path = dirpath / filename
                 paths.append(full_path.relative_to(root_path))
         return paths
-
-    def get_children(self) -> list[Path]:
-        root_path = self.get_root_path()
-        children = []
-        for full_child in root_path.iterdir():
-            children.append(full_child.relative_to(root_path))
-        return children

--- a/tests/test_ocfl_repository_gateway.py
+++ b/tests/test_ocfl_repository_gateway.py
@@ -11,8 +11,7 @@ from gateway.deposit_directory import DepositDirectory
 from gateway.exceptions import (
     NoStagedChangesError,
     ObjectDoesNotExistError,
-    StagedObjectAlreadyExistsError,
-    StagedObjectDoesNotExistError
+    StagedObjectAlreadyExistsError
 )
 from gateway.object_file import ObjectFile
 from gateway.ocfl_repository_gateway import OcflRepositoryGateway, StorageLayout
@@ -103,7 +102,7 @@ class OcflRepositoryGatewayTest(TestCase):
         gateway = OcflRepositoryGateway(self.pres_storage)
         gateway.create_repository()
         package = self.deposit_dir.get_package(Path("deposit_one"))
-        with self.assertRaises(StagedObjectDoesNotExistError):
+        with self.assertRaises(ObjectDoesNotExistError):
             gateway.stage_object_files("deposit_one", package)
 
     def test_gateway_commits_changes(self):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -8,7 +8,7 @@ from gateway.package import Package
 
 class PackageTest(TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.test_deposit_path: Path = Path("tests/fixtures/test_deposit")
         self.deposit_dir = DepositDirectory(self.test_deposit_path)
 
@@ -44,15 +44,3 @@ class PackageTest(TestCase):
             set([Path("A.txt"), Path("B/B.txt"), Path("C/D/D.txt")]),
             set(package.get_file_paths())
         )
-
-    def test_empty_package_provides_children(self):
-        package = Package(self.deposit_dir, Path("empty_deposit"))
-        self.assertTrue(len(package.get_children()) == 0)
-
-    def test_mixed_package_provides_children(self):
-        package = Package(self.deposit_dir, Path("deposit_one"))
-        self.assertSetEqual(
-            set([Path("A.txt"), Path("B"), Path("C")]),
-            set(package.get_children())
-        )
- 


### PR DESCRIPTION
This PR aims to resolve DOROP-31. It changes `OcflRepositoryGateway.stage_object_files` to issue individual `mv` commands for each file in the `Package` so that filtering of files (handled at the `Package` level) can be supported.