### PR TITLE
Resource path resolver

### DIFF
--- a/dor/providers/package_resource_provider.py
+++ b/dor/providers/package_resource_provider.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict
 
 from dor.providers.models import PackageResource
 from dor.providers.parsers import DescriptorFileParser

--- a/dor/providers/package_resource_provider.py
+++ b/dor/providers/package_resource_provider.py
@@ -35,12 +35,3 @@ class PackageResourceProvider:
             
         return package_resources
         
-    
-    def _apply_relative_path(self, descriptor_path: str, locref: str) -> str:
-        if locref.startswith("../"):
-            relative_path = (Path(descriptor_path).parent / locref).resolve()
-            return str(relative_path)
-        return locref
-    
-    def resolve_path(self, path: str, locref: str) -> str:
-        return self._apply_relative_path(path, locref)

--- a/dor/providers/package_resource_provider.py
+++ b/dor/providers/package_resource_provider.py
@@ -1,19 +1,46 @@
 from pathlib import Path
+from typing import Dict, List
 
-from .parsers import DescriptorFileParser
+from dor.providers.models import PackageResource
+from dor.providers.parsers import DescriptorFileParser
+from utils.element_adapter import ElementAdapter
 
 
 class PackageResourceProvider:
 
-    def __init__(self, data_path: Path):
-        self.data_path = data_path
+    namespaces: dict[str, str] = {
+        "METS": "http://www.loc.gov/METS/v2",
+        "PREMIS": "http://www.loc.gov/premis/v3",
+    }
+    
+    def __init__(self, descriptor_path: Path):
+        self.descriptor_path = descriptor_path
+        self._descriptor_files: Dict[Path, ElementAdapter] = {}
+        self._read_descriptor_files()
+
+    def _read_descriptor_files(self):
+        for file in self.descriptor_path.iterdir():
+            descriptor_text = file.read_text()
+            self._descriptor_files[file] = ElementAdapter.from_string(descriptor_text, self.namespaces)
 
     @property
     def descriptor_files(self):
-        descriptor_path = self.data_path / "descriptor"
-        return [file for file in descriptor_path.iterdir()]
-
-    def get_resources(self):
-        return [
-            DescriptorFileParser(file).get_resource() for file in self.descriptor_files
-        ]
+        return self._descriptor_files 
+    
+    def get_resources(self) -> list[PackageResource]:
+        package_resources: list[PackageResource] = []
+        for file_element in self._descriptor_files.values():
+            resource = DescriptorFileParser(file_element, self.descriptor_path).get_resource()
+            package_resources.append(resource)
+            
+        return package_resources
+        
+    
+    def _apply_relative_path(self, descriptor_path: str, locref: str) -> str:
+        if locref.startswith("../"):
+            relative_path = (Path(descriptor_path).parent / locref).resolve()
+            return str(relative_path)
+        return locref
+    
+    def resolve_path(self, path: str, locref: str) -> str:
+        return self._apply_relative_path(path, locref)

--- a/dor/providers/parsers.py
+++ b/dor/providers/parsers.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import Optional
 import uuid
 
 from utils.element_adapter import ElementAdapter
@@ -94,15 +94,15 @@ class DescriptorFileParser:
             ref=FileReference(locref=str(locref), mdtype=str(mdtype), mimetype=str(mimetype)),
         )
 
-    def get_struct_maps(self) -> List[StructMap]:
-        struct_maps: List[StructMap] = []
+    def get_struct_maps(self) -> list[StructMap]:
+        struct_maps: list[StructMap] = []
         for struct_map_elem in self.tree.findall(".//METS:structMap"):
             struct_map_id = struct_map_elem.get("ID")
             struct_map_type = struct_map_elem.get("TYPE")
 
             order_elems = struct_map_elem.findall(".//METS:div[@ORDER]")
 
-            struct_map_items: List[StructMapItem] = []
+            struct_map_items: list[StructMapItem] = []
             for order_elem in order_elems:
                 order_number = int(order_elem.get("ORDER"))
                 label = order_elem.get("LABEL")

--- a/dor/providers/parsers.py
+++ b/dor/providers/parsers.py
@@ -69,7 +69,7 @@ class DescriptorFileParser:
         mdtype: Optional[str] = None
         mimetype: Optional[str] = None 
         if md_red_element:
-            locref = self._apply_relative_path(self.descriptor_path, md_red_element.get_optional("LOCREF"), )
+            locref = self._apply_relative_path(self.descriptor_path, md_red_element.get_optional("LOCREF"))
             mdtype = md_red_element.get_optional("MDTYPE")
             mimetype = md_red_element.get_optional("MIMETYPE")
 
@@ -143,7 +143,10 @@ class DescriptorFileParser:
 
     def _apply_relative_path(self, descriptor_path: Path, path_to_apply: str) -> str:
         if path_to_apply.startswith("../"):
-            relative_path = (descriptor_path.parent / path_to_apply).resolve()
+            combined_path  =  (Path(descriptor_path).parent / path_to_apply)
+            print ("Desc:", Path(combined_path).resolve())
+            print(descriptor_path.parent)
+            relative_path = (Path(combined_path)).resolve().relative_to(descriptor_path.parent)
             return str(relative_path)
         return path_to_apply
     

--- a/dor/providers/parsers.py
+++ b/dor/providers/parsers.py
@@ -143,11 +143,7 @@ class DescriptorFileParser:
 
     def _apply_relative_path(self, descriptor_path: Path, path_to_apply: str) -> str:
         if path_to_apply.startswith("../"):
-            combined_path  =  (Path(descriptor_path).parent / path_to_apply)
-            print ("Desc:", Path(combined_path).resolve())
-            print(descriptor_path.parent)
-            relative_path = (Path(combined_path)).resolve().relative_to(descriptor_path.parent)
-            return str(relative_path)
+            combined_path = (descriptor_path / path_to_apply).resolve().relative_to(Path.cwd())
+            path_to_apply = str(combined_path)
         return path_to_apply
-    
-
+        

--- a/dor/providers/parsers.py
+++ b/dor/providers/parsers.py
@@ -7,11 +7,6 @@ from .models import *
 
 
 class DescriptorFileParser:
-    namespaces: dict[str, str] = {
-        "METS": "http://www.loc.gov/METS/v2",
-        "PREMIS": "http://www.loc.gov/premis/v3",
-    }
-
     def __init__(self, element_adapter: ElementAdapter, descriptor_path: Path):
         self.tree: ElementAdapter = element_adapter
         self.descriptor_path = descriptor_path

--- a/tests/test_descriptor_file_parser.py
+++ b/tests/test_descriptor_file_parser.py
@@ -290,7 +290,5 @@ class DescriptorFileParserTest(TestCase):
                 ),
             ],
         )
-       
-
         parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
         self.assertEqual(parser.get_resource(), expected_resource)

--- a/tests/test_descriptor_file_parser.py
+++ b/tests/test_descriptor_file_parser.py
@@ -66,135 +66,136 @@ class DescriptorFileParserTest(TestCase):
         parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
         self.assertEqual(parser.get_preservation_events(), expected_events)
 
-    # def test_parser_can_get_metadata_files(self):
+    def test_parser_can_get_metadata_files(self):
+        parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
+        expected_file_metadata = [
+            FileMetadata(
+                id="_0193972b-e591-7e28-b8cb-1babed52f606",
+                use="DESCRIPTIVE/COMMON",
+                ref=FileReference(
+                    locref="tests/fixtures/test_submission_package/xyzzy-0001-v1/data/00000000-0000-0000-0000-000000000001/metadata/00000000-0000-0000-0000-000000000001.common.json",
+                    mdtype="DOR:SCHEMA",
+                    mimetype="application/json",
+                ),
+            ),
+            FileMetadata(
+                id="_0193972b-e592-7647-8e51-10db514433f7",
+                use="DESCRIPTIVE",
+                ref=FileReference(
+                    locref="tests/fixtures/test_submission_package/xyzzy-0001-v1/data/00000000-0000-0000-0000-000000000001/metadata/00000000-0000-0000-0000-000000000001.metadata.json",
+                    mdtype="DOR:SCHEMA",
+                    mimetype="application/json",
+                ),
+            ),
+            FileMetadata(
+                id="RIGHTS1",
+                use="RIGHTS",
+                ref=FileReference(
+                    locref="https://creativecommons.org/publicdomain/zero/1.0/",
+                    mdtype="OTHER",
+                    mimetype="None"
+                ),
+            ),
+        ]
 
-    #     parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
-    #     expected_file_metadata = [
-    #         FileMetadata(
-    #             id="_0193972b-e591-7e28-b8cb-1babed52f606",
-    #             use="DESCRIPTIVE/COMMON",
-    #             ref=FileReference(
-    #                 locref="../metadata/00000000-0000-0000-0000-000000000001.common.json",
-    #                 mdtype="DOR:SCHEMA",
-    #                 mimetype="application/json",
-    #             ),
-    #         ),
-    #         FileMetadata(
-    #             id="_0193972b-e592-7647-8e51-10db514433f7",
-    #             use="DESCRIPTIVE",
-    #             ref=FileReference(
-    #                 locref="../metadata/00000000-0000-0000-0000-000000000001.metadata.json",
-    #                 mdtype="DOR:SCHEMA",
-    #                 mimetype="application/json",
-    #             ),
-    #         ),
-    #         FileMetadata(
-    #             id="RIGHTS1",
-    #             use="RIGHTS",
-    #             ref=FileReference(
-    #                 locref="https://creativecommons.org/publicdomain/zero/1.0/",
-    #                 mdtype="OTHER",
-    #             ),
-    #         ),
-    #     ]
+        self.assertEqual(parser.get_metadata_files(), expected_file_metadata)
 
-    #     self.assertEqual(parser.get_metadata_files(), expected_file_metadata)
+    def test_parser_can_get_struct_maps(self):
 
-    # def test_parser_can_get_struct_maps(self):
+        parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
+        expected_struct_maps = [
+            StructMap(
+                id="SM1",
+                type=StructMapType.PHYSICAL,
+                items=[
+                    StructMapItem(
+                        order=1,
+                        type="page",
+                        label="Page 1",
+                        asset_id="urn:dor:00000000-0000-0000-0000-000000001001",
+                    ),
+                    StructMapItem(
+                        order=2,
+                        type="page",
+                        label="Page 2",
+                        asset_id="urn:dor:00000000-0000-0000-0000-000000001002",
+                    ),
+                ],
+            )
+        ]
 
-    #     parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
-    #     expected_struct_maps = [
-    #         StructMap(
-    #             id="SM1",
-    #             type=StructMapType.PHYSICAL,
-    #             items=[
-    #                 StructMapItem(
-    #                     order=1,
-    #                     type="page",
-    #                     label="Page 1",
-    #                     asset_id="urn:dor:00000000-0000-0000-0000-000000001001",
-    #                 ),
-    #                 StructMapItem(
-    #                     order=2,
-    #                     type="page",
-    #                     label="Page 2",
-    #                     asset_id="urn:dor:00000000-0000-0000-0000-000000001002",
-    #                 ),
-    #             ],
-    #         )
-    #     ]
+        self.assertEqual(parser.get_struct_maps(), expected_struct_maps)
 
-    #     self.assertEqual(parser.get_struct_maps(), expected_struct_maps)
+    def test_parser_can_parse_monograph(self):
 
-    # def test_parser_can_parse_monograph(self):
+        expected_resource = PackageResource(
+            id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+            type="Monograph",
+            alternate_identifier=AlternateIdentifier(id="xyzzy:00000001", type="DLXS"),
+            events=[
+                PreservationEvent(
+                    identifier="e01727d0-b4d9-47a5-925a-4018f9cac6b8",
+                    type="ingest",
+                    datetime=datetime(1983, 5, 17, 11, 9, 45, tzinfo=UTC),
+                    detail="Girl voice lot another blue nearly.",
+                    agent=Agent(
+                        address="matthew24@example.net", role="collection manager"
+                    ),
+                )
+            ],
+            metadata_files=[
+                FileMetadata(
+                    id="_0193972b-e591-7e28-b8cb-1babed52f606",
+                    use="DESCRIPTIVE/COMMON",
+                    ref=FileReference(
+                        locref="tests/fixtures/test_submission_package/xyzzy-0001-v1/data/00000000-0000-0000-0000-000000000001/metadata/00000000-0000-0000-0000-000000000001.common.json",
+                        mdtype="DOR:SCHEMA",
+                        mimetype="application/json",
+                    ),
+                ),
+                FileMetadata(
+                    id="_0193972b-e592-7647-8e51-10db514433f7",
+                    use="DESCRIPTIVE",
+                    ref=FileReference(
+                        locref="tests/fixtures/test_submission_package/xyzzy-0001-v1/data/00000000-0000-0000-0000-000000000001/metadata/00000000-0000-0000-0000-000000000001.metadata.json",
+                        mdtype="DOR:SCHEMA",
+                        mimetype="application/json",
+                    ),
+                ),
+                FileMetadata(
+                    id="RIGHTS1",
+                    use="RIGHTS",
+                    ref=FileReference(
+                        locref="https://creativecommons.org/publicdomain/zero/1.0/",
+                        mdtype="OTHER",
+                        mimetype="None"
+                    ),
+                ),
+            ],
+            struct_maps=[
+                StructMap(
+                    id="SM1",
+                    type=StructMapType.PHYSICAL,
+                    items=[
+                        StructMapItem(
+                            order=1,
+                            type="page",
+                            label="Page 1",
+                            asset_id="urn:dor:00000000-0000-0000-0000-000000001001",
+                        ),
+                        StructMapItem(
+                            order=2,
+                            type="page",
+                            label="Page 2",
+                            asset_id="urn:dor:00000000-0000-0000-0000-000000001002",
+                        ),
+                    ],
+                )
+            ],
+        )
 
-    #     expected_resource = PackageResource(
-    #         id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
-    #         type="Monograph",
-    #         alternate_identifier=AlternateIdentifier(id="xyzzy:00000001", type="DLXS"),
-    #         events=[
-    #             PreservationEvent(
-    #                 identifier="e01727d0-b4d9-47a5-925a-4018f9cac6b8",
-    #                 type="ingest",
-    #                 datetime=datetime(1983, 5, 17, 11, 9, 45, tzinfo=UTC),
-    #                 detail="Girl voice lot another blue nearly.",
-    #                 agent=Agent(
-    #                     address="matthew24@example.net", role="collection manager"
-    #                 ),
-    #             )
-    #         ],
-    #         metadata_files=[
-    #             FileMetadata(
-    #                 id="_0193972b-e591-7e28-b8cb-1babed52f606",
-    #                 use="DESCRIPTIVE/COMMON",
-    #                 ref=FileReference(
-    #                     locref="../metadata/00000000-0000-0000-0000-000000000001.common.json",
-    #                     mdtype="DOR:SCHEMA",
-    #                     mimetype="application/json",
-    #                 ),
-    #             ),
-    #             FileMetadata(
-    #                 id="_0193972b-e592-7647-8e51-10db514433f7",
-    #                 use="DESCRIPTIVE",
-    #                 ref=FileReference(
-    #                     locref="../metadata/00000000-0000-0000-0000-000000000001.metadata.json",
-    #                     mdtype="DOR:SCHEMA",
-    #                     mimetype="application/json",
-    #                 ),
-    #             ),
-    #             FileMetadata(
-    #                 id="RIGHTS1",
-    #                 use="RIGHTS",
-    #                 ref=FileReference(
-    #                     locref="https://creativecommons.org/publicdomain/zero/1.0/",
-    #                     mdtype="OTHER",
-    #                 ),
-    #             ),
-    #         ],
-    #         struct_maps=[
-    #             StructMap(
-    #                 id="SM1",
-    #                 type=StructMapType.PHYSICAL,
-    #                 items=[
-    #                     StructMapItem(
-    #                         order=1,
-    #                         type="page",
-    #                         label="Page 1",
-    #                         asset_id="urn:dor:00000000-0000-0000-0000-000000001001",
-    #                     ),
-    #                     StructMapItem(
-    #                         order=2,
-    #                         type="page",
-    #                         label="Page 2",
-    #                         asset_id="urn:dor:00000000-0000-0000-0000-000000001002",
-    #                     ),
-    #                 ],
-    #             )
-    #         ],
-    #     )
-
-    #     parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
-    #     self.assertEqual(parser.get_resource(), expected_resource)
+        parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
+        self.assertEqual(parser.get_resource(), expected_resource)
 
     def test_parser_can_parse_asset(self):
         base_path = Path("/app")
@@ -230,24 +231,27 @@ class DescriptorFileParserTest(TestCase):
                     id="_0193972b-e4a4-7985-abe2-f3f1259b78ec",
                     use="TECHNICAL",
                     ref=FileReference(
-                        locref="../metadata/00000001.source.jpg.mix.xml",
+                        locref="tests/fixtures/test_submission_package/xyzzy-0001-v1/data/00000000-0000-0000-0000-000000000001/metadata/00000001.source.jpg.mix.xml",
                         mdtype="NISOIMG",
+                        mimetype="None"
                     ),
                 ),
                 FileMetadata(
                     id="_0193972b-e4ae-73eb-848d-5f8893b68253",
                     use="TECHNICAL",
                     ref=FileReference(
-                        locref="../metadata/00000001.access.jpg.mix.xml",
+                        locref="tests/fixtures/test_submission_package/xyzzy-0001-v1/data/00000000-0000-0000-0000-000000000001/metadata/00000001.access.jpg.mix.xml",
                         mdtype="NISOIMG",
+                        mimetype="None"
                     ),
                 ),
                 FileMetadata(
                     id="_0193972b-e572-7107-b69c-e2f4c660a9aa",
                     use="TECHNICAL",
                     ref=FileReference(
-                        locref="../metadata/00000001.plaintext.txt.textmd.xml",
+                        locref="tests/fixtures/test_submission_package/xyzzy-0001-v1/data/00000000-0000-0000-0000-000000000001/metadata/00000001.plaintext.txt.textmd.xml",
                         mdtype="TEXTMD",
+                        mimetype="None"
                     ),
                 ),
             ],
@@ -257,8 +261,9 @@ class DescriptorFileParserTest(TestCase):
                     mdid="_0193972b-e4a4-7985-abe2-f3f1259b78ec",
                     use="SOURCE",
                     ref=FileReference(
-                        locref="../data/00000001.source.jpg",
+                        locref="tests/fixtures/test_submission_package/xyzzy-0001-v1/data/00000000-0000-0000-0000-000000000001/data/00000001.source.jpg",
                         mimetype="image/jpeg",
+                        mdtype="None"
                     ),
                 ),
                 FileMetadata(
@@ -267,8 +272,9 @@ class DescriptorFileParserTest(TestCase):
                     mdid="_0193972b-e4ae-73eb-848d-5f8893b68253",
                     use="ACCESS",
                     ref=FileReference(
-                        locref="../data/00000001.access.jpg",
+                        locref="tests/fixtures/test_submission_package/xyzzy-0001-v1/data/00000000-0000-0000-0000-000000000001/data/00000001.access.jpg",
                         mimetype="image/jpeg",
+                        mdtype="None"
                     ),
                 ),
                 FileMetadata(
@@ -277,15 +283,14 @@ class DescriptorFileParserTest(TestCase):
                     mdid="_0193972b-e572-7107-b69c-e2f4c660a9aa",
                     use="SOURCE",
                     ref=FileReference(
-                        locref="../data/00000001.plaintext.txt",
+                        locref="tests/fixtures/test_submission_package/xyzzy-0001-v1/data/00000000-0000-0000-0000-000000000001/data/00000001.plaintext.txt",
                         mimetype="text/plain",
+                        mdtype="None"
                     ),
                 ),
             ],
         )
+       
 
-        parser = DescriptorFileParser(self.mets2_resource, descriptor_path)
-        print(expected_resource)
-        print("next....")
-        print(parser.get_resource())
+        parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
         self.assertEqual(parser.get_resource(), expected_resource)

--- a/tests/test_descriptor_file_parser.py
+++ b/tests/test_descriptor_file_parser.py
@@ -26,11 +26,12 @@ class DescriptorFileParserTest(TestCase):
             / "data"
             / "00000000-0000-0000-0000-000000000001"
             / "descriptor")
-        resource_provider = PackageResourceProvider(self.exact_descriptor_path)
+        self.resource_provider = PackageResourceProvider(self.exact_descriptor_path)
         self.mets2_resource = None
 
-        if self.descriptor_path in resource_provider.descriptor_files:
-            self.mets2_resource = resource_provider.descriptor_files[self.descriptor_path]
+        if self.descriptor_path in self.resource_provider.descriptor_files:
+            self.mets2_resource = self.resource_provider.descriptor_files[self.descriptor_path]
+            
 
         return super().setUp()
 
@@ -65,143 +66,143 @@ class DescriptorFileParserTest(TestCase):
         parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
         self.assertEqual(parser.get_preservation_events(), expected_events)
 
-    def test_parser_can_get_metadata_files(self):
+    # def test_parser_can_get_metadata_files(self):
 
-        parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
-        expected_file_metadata = [
-            FileMetadata(
-                id="_0193972b-e591-7e28-b8cb-1babed52f606",
-                use="DESCRIPTIVE/COMMON",
-                ref=FileReference(
-                    locref="../metadata/00000000-0000-0000-0000-000000000001.common.json",
-                    mdtype="DOR:SCHEMA",
-                    mimetype="application/json",
-                ),
-            ),
-            FileMetadata(
-                id="_0193972b-e592-7647-8e51-10db514433f7",
-                use="DESCRIPTIVE",
-                ref=FileReference(
-                    locref="../metadata/00000000-0000-0000-0000-000000000001.metadata.json",
-                    mdtype="DOR:SCHEMA",
-                    mimetype="application/json",
-                ),
-            ),
-            FileMetadata(
-                id="RIGHTS1",
-                use="RIGHTS",
-                ref=FileReference(
-                    locref="https://creativecommons.org/publicdomain/zero/1.0/",
-                    mdtype="OTHER",
-                ),
-            ),
-        ]
+    #     parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
+    #     expected_file_metadata = [
+    #         FileMetadata(
+    #             id="_0193972b-e591-7e28-b8cb-1babed52f606",
+    #             use="DESCRIPTIVE/COMMON",
+    #             ref=FileReference(
+    #                 locref="../metadata/00000000-0000-0000-0000-000000000001.common.json",
+    #                 mdtype="DOR:SCHEMA",
+    #                 mimetype="application/json",
+    #             ),
+    #         ),
+    #         FileMetadata(
+    #             id="_0193972b-e592-7647-8e51-10db514433f7",
+    #             use="DESCRIPTIVE",
+    #             ref=FileReference(
+    #                 locref="../metadata/00000000-0000-0000-0000-000000000001.metadata.json",
+    #                 mdtype="DOR:SCHEMA",
+    #                 mimetype="application/json",
+    #             ),
+    #         ),
+    #         FileMetadata(
+    #             id="RIGHTS1",
+    #             use="RIGHTS",
+    #             ref=FileReference(
+    #                 locref="https://creativecommons.org/publicdomain/zero/1.0/",
+    #                 mdtype="OTHER",
+    #             ),
+    #         ),
+    #     ]
 
-        self.assertEqual(parser.get_metadata_files(), expected_file_metadata)
+    #     self.assertEqual(parser.get_metadata_files(), expected_file_metadata)
 
-    def test_parser_can_get_struct_maps(self):
+    # def test_parser_can_get_struct_maps(self):
 
-        parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
-        expected_struct_maps = [
-            StructMap(
-                id="SM1",
-                type=StructMapType.PHYSICAL,
-                items=[
-                    StructMapItem(
-                        order=1,
-                        type="page",
-                        label="Page 1",
-                        asset_id="urn:dor:00000000-0000-0000-0000-000000001001",
-                    ),
-                    StructMapItem(
-                        order=2,
-                        type="page",
-                        label="Page 2",
-                        asset_id="urn:dor:00000000-0000-0000-0000-000000001002",
-                    ),
-                ],
-            )
-        ]
+    #     parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
+    #     expected_struct_maps = [
+    #         StructMap(
+    #             id="SM1",
+    #             type=StructMapType.PHYSICAL,
+    #             items=[
+    #                 StructMapItem(
+    #                     order=1,
+    #                     type="page",
+    #                     label="Page 1",
+    #                     asset_id="urn:dor:00000000-0000-0000-0000-000000001001",
+    #                 ),
+    #                 StructMapItem(
+    #                     order=2,
+    #                     type="page",
+    #                     label="Page 2",
+    #                     asset_id="urn:dor:00000000-0000-0000-0000-000000001002",
+    #                 ),
+    #             ],
+    #         )
+    #     ]
 
-        self.assertEqual(parser.get_struct_maps(), expected_struct_maps)
+    #     self.assertEqual(parser.get_struct_maps(), expected_struct_maps)
 
-    def test_parser_can_parse_monograph(self):
+    # def test_parser_can_parse_monograph(self):
 
-        expected_resource = PackageResource(
-            id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
-            type="Monograph",
-            alternate_identifier=AlternateIdentifier(id="xyzzy:00000001", type="DLXS"),
-            events=[
-                PreservationEvent(
-                    identifier="e01727d0-b4d9-47a5-925a-4018f9cac6b8",
-                    type="ingest",
-                    datetime=datetime(1983, 5, 17, 11, 9, 45, tzinfo=UTC),
-                    detail="Girl voice lot another blue nearly.",
-                    agent=Agent(
-                        address="matthew24@example.net", role="collection manager"
-                    ),
-                )
-            ],
-            metadata_files=[
-                FileMetadata(
-                    id="_0193972b-e591-7e28-b8cb-1babed52f606",
-                    use="DESCRIPTIVE/COMMON",
-                    ref=FileReference(
-                        locref="../metadata/00000000-0000-0000-0000-000000000001.common.json",
-                        mdtype="DOR:SCHEMA",
-                        mimetype="application/json",
-                    ),
-                ),
-                FileMetadata(
-                    id="_0193972b-e592-7647-8e51-10db514433f7",
-                    use="DESCRIPTIVE",
-                    ref=FileReference(
-                        locref="../metadata/00000000-0000-0000-0000-000000000001.metadata.json",
-                        mdtype="DOR:SCHEMA",
-                        mimetype="application/json",
-                    ),
-                ),
-                FileMetadata(
-                    id="RIGHTS1",
-                    use="RIGHTS",
-                    ref=FileReference(
-                        locref="https://creativecommons.org/publicdomain/zero/1.0/",
-                        mdtype="OTHER",
-                    ),
-                ),
-            ],
-            struct_maps=[
-                StructMap(
-                    id="SM1",
-                    type=StructMapType.PHYSICAL,
-                    items=[
-                        StructMapItem(
-                            order=1,
-                            type="page",
-                            label="Page 1",
-                            asset_id="urn:dor:00000000-0000-0000-0000-000000001001",
-                        ),
-                        StructMapItem(
-                            order=2,
-                            type="page",
-                            label="Page 2",
-                            asset_id="urn:dor:00000000-0000-0000-0000-000000001002",
-                        ),
-                    ],
-                )
-            ],
-        )
+    #     expected_resource = PackageResource(
+    #         id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+    #         type="Monograph",
+    #         alternate_identifier=AlternateIdentifier(id="xyzzy:00000001", type="DLXS"),
+    #         events=[
+    #             PreservationEvent(
+    #                 identifier="e01727d0-b4d9-47a5-925a-4018f9cac6b8",
+    #                 type="ingest",
+    #                 datetime=datetime(1983, 5, 17, 11, 9, 45, tzinfo=UTC),
+    #                 detail="Girl voice lot another blue nearly.",
+    #                 agent=Agent(
+    #                     address="matthew24@example.net", role="collection manager"
+    #                 ),
+    #             )
+    #         ],
+    #         metadata_files=[
+    #             FileMetadata(
+    #                 id="_0193972b-e591-7e28-b8cb-1babed52f606",
+    #                 use="DESCRIPTIVE/COMMON",
+    #                 ref=FileReference(
+    #                     locref="../metadata/00000000-0000-0000-0000-000000000001.common.json",
+    #                     mdtype="DOR:SCHEMA",
+    #                     mimetype="application/json",
+    #                 ),
+    #             ),
+    #             FileMetadata(
+    #                 id="_0193972b-e592-7647-8e51-10db514433f7",
+    #                 use="DESCRIPTIVE",
+    #                 ref=FileReference(
+    #                     locref="../metadata/00000000-0000-0000-0000-000000000001.metadata.json",
+    #                     mdtype="DOR:SCHEMA",
+    #                     mimetype="application/json",
+    #                 ),
+    #             ),
+    #             FileMetadata(
+    #                 id="RIGHTS1",
+    #                 use="RIGHTS",
+    #                 ref=FileReference(
+    #                     locref="https://creativecommons.org/publicdomain/zero/1.0/",
+    #                     mdtype="OTHER",
+    #                 ),
+    #             ),
+    #         ],
+    #         struct_maps=[
+    #             StructMap(
+    #                 id="SM1",
+    #                 type=StructMapType.PHYSICAL,
+    #                 items=[
+    #                     StructMapItem(
+    #                         order=1,
+    #                         type="page",
+    #                         label="Page 1",
+    #                         asset_id="urn:dor:00000000-0000-0000-0000-000000001001",
+    #                     ),
+    #                     StructMapItem(
+    #                         order=2,
+    #                         type="page",
+    #                         label="Page 2",
+    #                         asset_id="urn:dor:00000000-0000-0000-0000-000000001002",
+    #                     ),
+    #                 ],
+    #             )
+    #         ],
+    #     )
 
-        parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
-        self.assertEqual(parser.get_resource(), expected_resource)
+    #     parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
+    #     self.assertEqual(parser.get_resource(), expected_resource)
 
     def test_parser_can_parse_asset(self):
-        descriptor_path = ( 
-            self.descriptor_path 
-            / ".." 
-            / "00000000-0000-0000-0000-000000001001.asset.mets2.xml" 
-        ).resolve()
+        base_path = Path("/app")
+        descriptor_path = (
+            (self.descriptor_path / ".." / "00000000-0000-0000-0000-000000001001.asset.mets2.xml").resolve().relative_to(base_path)
+        )
 
+        self.mets2_resource = self.resource_provider.descriptor_files[Path(descriptor_path)]
         expected_resource = PackageResource(
             id=uuid.UUID("00000000-0000-0000-0000-000000001001"),
             type="Asset",
@@ -283,6 +284,8 @@ class DescriptorFileParserTest(TestCase):
             ],
         )
 
-        parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
+        parser = DescriptorFileParser(self.mets2_resource, descriptor_path)
         print(expected_resource)
+        print("next....")
+        print(parser.get_resource())
         self.assertEqual(parser.get_resource(), expected_resource)

--- a/tests/test_descriptor_file_parser.py
+++ b/tests/test_descriptor_file_parser.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from datetime import datetime, UTC
 import uuid
 
+from dor.providers.package_resource_provider import PackageResourceProvider
 from dor.providers.parsers import *
 from dor.providers.models import *
 
@@ -19,21 +20,32 @@ class DescriptorFileParserTest(TestCase):
             / "descriptor"
             / "00000000-0000-0000-0000-000000000001.monograph.mets2.xml"
         )
+        self.exact_descriptor_path = (
+            self.test_submission_path
+            / "xyzzy-0001-v1"
+            / "data"
+            / "00000000-0000-0000-0000-000000000001"
+            / "descriptor")
+        resource_provider = PackageResourceProvider(self.exact_descriptor_path)
+        self.mets2_resource = None
+
+        if self.descriptor_path in resource_provider.descriptor_files:
+            self.mets2_resource = resource_provider.descriptor_files[self.descriptor_path]
 
         return super().setUp()
 
     def test_parser_can_get_id(self):
-        parser = DescriptorFileParser(self.descriptor_path)
+        parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
         self.assertEqual(parser.get_id(), uuid.UUID("00000000-0000-0000-0000-000000000001"))
 
     def test_parser_can_get_type(self):
-        parser = DescriptorFileParser(self.descriptor_path)
+        parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
         self.assertEqual(
             parser.get_type(), "Monograph"
         )
 
     def test_parser_can_get_alternate_identifier(self):
-        parser = DescriptorFileParser(self.descriptor_path)
+        parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
 
         expected_identifier = AlternateIdentifier(type="DLXS", id="xyzzy:00000001")
 
@@ -50,12 +62,12 @@ class DescriptorFileParserTest(TestCase):
             )
         ]
 
-        parser = DescriptorFileParser(self.descriptor_path)
+        parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
         self.assertEqual(parser.get_preservation_events(), expected_events)
 
     def test_parser_can_get_metadata_files(self):
 
-        parser = DescriptorFileParser(self.descriptor_path)
+        parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
         expected_file_metadata = [
             FileMetadata(
                 id="_0193972b-e591-7e28-b8cb-1babed52f606",
@@ -89,7 +101,7 @@ class DescriptorFileParserTest(TestCase):
 
     def test_parser_can_get_struct_maps(self):
 
-        parser = DescriptorFileParser(self.descriptor_path)
+        parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
         expected_struct_maps = [
             StructMap(
                 id="SM1",
@@ -180,7 +192,7 @@ class DescriptorFileParserTest(TestCase):
             ],
         )
 
-        parser = DescriptorFileParser(self.descriptor_path)
+        parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
         self.assertEqual(parser.get_resource(), expected_resource)
 
     def test_parser_can_parse_asset(self):
@@ -271,5 +283,6 @@ class DescriptorFileParserTest(TestCase):
             ],
         )
 
-        parser = DescriptorFileParser(descriptor_path)
+        parser = DescriptorFileParser(self.mets2_resource, self.exact_descriptor_path)
+        print(expected_resource)
         self.assertEqual(parser.get_resource(), expected_resource)

--- a/tests/test_package_resource_provider.py
+++ b/tests/test_package_resource_provider.py
@@ -2,52 +2,51 @@ from pathlib import Path
 from unittest import TestCase
 
 from dor.providers.package_resource_provider import PackageResourceProvider
-from dor.providers.package_resource_provider import *
+from dor.providers.parsers import DescriptorFileParser
+# from dor.providers.package_resource_provider import *
 
 
 class PackageResourceProviderTest(TestCase):
 
     def setUp(self):
         self.test_submission_path = Path("tests/fixtures/test_submission_package")
-        self.data_path = (
+        self.descriptor_path = (
             self.test_submission_path
             / "xyzzy-0001-v1"
             / "data"
             / "00000000-0000-0000-0000-000000000001"
+            / "descriptor"
         )
 
         return super().setUp()
 
     def test_provider_can_be_set_up(self):
-        provider = PackageResourceProvider(self.data_path)
+        provider = PackageResourceProvider(self.descriptor_path)
 
     def test_provider_can_find_descriptors(self):
 
         expected_files = []
 
         expected_files.append(
-            self.data_path
-            / "descriptor"
+            self.descriptor_path
             / "00000000-0000-0000-0000-000000000001.monograph.mets2.xml"
         )
         expected_files.append(
-            self.data_path
-            / "descriptor"
+            self.descriptor_path
             / "00000000-0000-0000-0000-000000001001.asset.mets2.xml"
         )
         expected_files.append(
-            self.data_path
-            / "descriptor"
+            self.descriptor_path
             / "00000000-0000-0000-0000-000000001002.asset.mets2.xml"
         )
 
-        provider = PackageResourceProvider(self.data_path)
+        provider = PackageResourceProvider(self.descriptor_path)
         descriptor_files = provider.descriptor_files
         self.assertSetEqual(set(descriptor_files), set(expected_files))
 
     def test_provider_can_parse_resources(self):
 
-        provider = PackageResourceProvider(self.data_path)
+        provider = PackageResourceProvider(self.descriptor_path)
 
         resources = provider.get_resources()
         self.assertEqual(len(resources), 3)


### PR DESCRIPTION
I moved the _apply_relative_path method to the Parser class instead of PackageResourceProvider to avoid a circular dependency. Additionally, since the resolution of the path for locref is now happening within the parser, I added the _apply_relative_path method there.

Please let me know if you think this approach is sound or if you have any alternative suggestions.