### PR TITLE
catalog.get should return a list of PackageResource

### DIFF
--- a/dor/adapters/catalog.py
+++ b/dor/adapters/catalog.py
@@ -8,6 +8,8 @@ from sqlalchemy.orm import registry
 from pydantic_core import to_jsonable_python
 import json
 
+from dor.providers.models import PackageResource
+
 mapper_registry = registry()
 
 def _custom_json_serializer(*args, **kwargs) -> str:
@@ -58,7 +60,10 @@ class SqlalchemyCatalog:
         statement = select(Bin).where(Bin.identifier == identifier)
         results = self.session.execute(statement).one()
         if len(results) == 1:
-            return results[0]
+            result = results[0]
+            for i, resource in enumerate(result.package_resources):
+                result.package_resources[i] = PackageResource(**resource)
+            return result
         return None
 
 

--- a/dor/domain/models.py
+++ b/dor/domain/models.py
@@ -1,5 +1,5 @@
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from gateway.coordinator import Coordinator
@@ -10,6 +10,7 @@ from dor.providers.models import PackageResource
 class VersionInfo():
     coordinator: Coordinator
     message: str
+
 
 @dataclass
 class Bin:

--- a/dor/providers/models.py
+++ b/dor/providers/models.py
@@ -1,24 +1,28 @@
 # from dataclasses import dataclass, field
 from dataclasses import field
-# from pydantic.dataclasses import dataclass
-from pydantic import BaseModel
+from pydantic.dataclasses import dataclass
+# from pydantic import BaseModel
+from typing import Optional
 
 import uuid
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
 
-class AlternateIdentifier(BaseModel):
+@dataclass
+class AlternateIdentifier:
     type: str
     id: str
 
 
-class Agent(BaseModel):
+@dataclass
+class Agent:
     address: str
     role: str
 
 
-class PreservationEvent(BaseModel):
+@dataclass
+class PreservationEvent:
     identifier: str
     type: str
     datetime: datetime
@@ -26,17 +30,19 @@ class PreservationEvent(BaseModel):
     agent: Agent
 
 
-class FileReference(BaseModel):
+@dataclass
+class FileReference:
     locref: str
-    mdtype: str = None
-    mimetype: str = None
+    mdtype: Optional[str] = None
+    mimetype: Optional[str] = None
 
 
-class FileMetadata(BaseModel):
+@dataclass
+class FileMetadata:
     id: str
     use: str
-    mdid: str = None
-    groupid: str = None
+    mdid: Optional[str] = None
+    groupid: Optional[str] = None
     ref: FileReference = None
 
 
@@ -45,20 +51,23 @@ class StructMapType(Enum):
     LOGICAL = "LOGICAL"
 
 
-class StructMapItem(BaseModel):
+@dataclass
+class StructMapItem:
     order: int
     label: str
     asset_id: str
-    type: str = None
+    type: Optional[str] = None
 
 
-class StructMap(BaseModel):
+@dataclass
+class StructMap:
     id: str
     type: StructMapType
     items: list[StructMapItem]
 
 
-class PackageResource(BaseModel):
+@dataclass
+class PackageResource:
     id: uuid.UUID
     type: str
     alternate_identifier: AlternateIdentifier

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 import json
+import copy
 
 import pytest
 import sqlalchemy
@@ -211,7 +212,7 @@ def sample_bin() -> Bin:
 def test_catalog_adds_bin(db_session, sample_bin) -> None:
     catalog = SqlalchemyCatalog(db_session)
     with db_session.begin():
-        catalog.add(sample_bin)
+        catalog.add(copy.deepcopy(sample_bin))
         db_session.commit()
 
     rows = list(
@@ -228,7 +229,7 @@ def test_catalog_adds_bin(db_session, sample_bin) -> None:
 def test_catalog_gets_bin(db_session, sample_bin) -> None:
     catalog = SqlalchemyCatalog(db_session)
     with db_session.begin():
-        catalog.add(sample_bin)
+        catalog.add(copy.deepcopy(sample_bin))
         db_session.commit()
 
     bin = catalog.get("00000000-0000-0000-0000-000000000001")


### PR DESCRIPTION
Shameless feldgrau to have `catalog.get` return a list of `PackageResource` instead of `dict`.

Discovered that the `catalog.add(sample_bin)` was changing the contents of `sample_bin` so it contained a list of `dict` instead of `PackageResource` which is why the tests were passing. Huzzah!

