### PR TITLE
DOROP-30 - generate preservation descriptors

### DIFF
--- a/dor/providers/descriptor_generator.py
+++ b/dor/providers/descriptor_generator.py
@@ -10,25 +10,20 @@ class DescriptorGenerator:
         self.bin = bin
 
     def write_files(self):
-        filenames = []
-        asset_map = {}
+        struct_map_locref_data = {}
         for resource in self.bin.package_resources:
             if resource.type == "Asset":
                 identifier = f"urn:dor:{resource.id}"
-                asset_map[identifier] = f"{resource.id}.mets2.xml"
+                struct_map_locref_data[identifier] = f"{resource.id}.{resource.type.lower()}.mets2.xml"
 
         entity_template = template_env.get_template("preservation_mets.xml")
         for resource in self.bin.package_resources:
             xmldata = entity_template.render(
                 resource=resource,
-                asset_map=asset_map,
+                struct_map_locref_data=struct_map_locref_data,
                 action="stored",
                 create_date=datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
             )
-            filename = self.output_path / f"{resource.id}_{resource.type.lower()}.xml"
+            filename = self.output_path / f"{resource.id}.{resource.type.lower()}.mets2.xml"
             with filename.open("w") as f:
                 f.write(xmldata)
-
-            filenames.append(filename)
-
-        return filenames

--- a/dor/providers/descriptor_generator.py
+++ b/dor/providers/descriptor_generator.py
@@ -5,8 +5,8 @@ from dor.settings import S, template_env
 from dor.providers.models import PackageResource
 
 class DescriptorGenerator:
-    def __init__(self, output_path: Path, resources: list[PackageResource]):
-        self.output_path = output_path
+    def __init__(self, package_path: Path, resources: list[PackageResource]):
+        self.package_path = package_path
         self.resources = resources
 
     def write_files(self):
@@ -24,6 +24,6 @@ class DescriptorGenerator:
                 action="stored",
                 create_date=datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
             )
-            filename = self.output_path / f"{resource.id}.{resource.type.lower()}.mets2.xml"
-            with filename.open("w") as f:
+            filename = Path(f"descriptor/{resource.id}.{resource.type.lower()}.mets2.xml")
+            with (self.package_path / filename).open("w") as f:
                 f.write(xmldata)

--- a/dor/providers/descriptor_generator.py
+++ b/dor/providers/descriptor_generator.py
@@ -4,6 +4,11 @@ from datetime import datetime, UTC
 from dor.settings import S, template_env
 from dor.providers.models import PackageResource
 
+def relative_path_or_not(locref: str):
+    if locref.startswith("https://"):
+        return locref
+    return f"../{locref}"
+
 class DescriptorGenerator:
     def __init__(self, package_path: Path, resources: list[PackageResource]):
         self.package_path = package_path
@@ -20,6 +25,7 @@ class DescriptorGenerator:
         entity_template = template_env.get_template("preservation_mets.xml")
         for resource in self.resources:
             xmldata = entity_template.render(
+                relative_path_or_not=relative_path_or_not,
                 resource=resource,
                 struct_map_locref_data=struct_map_locref_data,
                 action="stored",

--- a/dor/providers/descriptor_generator.py
+++ b/dor/providers/descriptor_generator.py
@@ -2,22 +2,22 @@ from pathlib import Path
 from datetime import datetime, UTC
 
 from dor.settings import S, template_env
-from dor.domain.models import Bin
+from dor.providers.models import PackageResource
 
 class DescriptorGenerator:
-    def __init__(self, output_path: Path, bin: Bin):
+    def __init__(self, output_path: Path, resources: list[PackageResource]):
         self.output_path = output_path
-        self.bin = bin
+        self.resources = resources
 
     def write_files(self):
         struct_map_locref_data = {}
-        for resource in self.bin.package_resources:
+        for resource in self.resources:
             if resource.type == "Asset":
                 identifier = f"urn:dor:{resource.id}"
                 struct_map_locref_data[identifier] = f"{resource.id}.{resource.type.lower()}.mets2.xml"
 
         entity_template = template_env.get_template("preservation_mets.xml")
-        for resource in self.bin.package_resources:
+        for resource in self.resources:
             xmldata = entity_template.render(
                 resource=resource,
                 struct_map_locref_data=struct_map_locref_data,

--- a/dor/providers/descriptor_generator.py
+++ b/dor/providers/descriptor_generator.py
@@ -8,6 +8,7 @@ class DescriptorGenerator:
     def __init__(self, package_path: Path, resources: list[PackageResource]):
         self.package_path = package_path
         self.resources = resources
+        self.entries = []
 
     def write_files(self):
         struct_map_locref_data = {}
@@ -27,3 +28,4 @@ class DescriptorGenerator:
             filename = Path(f"descriptor/{resource.id}.{resource.type.lower()}.mets2.xml")
             with (self.package_path / filename).open("w") as f:
                 f.write(xmldata)
+            self.entries.append(filename)

--- a/dor/providers/descriptor_generator.py
+++ b/dor/providers/descriptor_generator.py
@@ -1,13 +1,16 @@
 from pathlib import Path
 from datetime import datetime, UTC
 
-from dor.settings import S, template_env
+from dor.settings import template_env
 from dor.providers.models import PackageResource
 
 def relative_path_or_not(locref: str):
     if locref.startswith("https://"):
         return locref
     return f"../{locref}"
+
+def build_descriptor_filename(resource):
+    return f"{resource.id}.{resource.type.lower()}.mets2.xml"
 
 class DescriptorGenerator:
     def __init__(self, package_path: Path, resources: list[PackageResource]):
@@ -20,7 +23,7 @@ class DescriptorGenerator:
         for resource in self.resources:
             if resource.type == "Asset":
                 identifier = f"urn:dor:{resource.id}"
-                struct_map_locref_data[identifier] = f"{resource.id}.{resource.type.lower()}.mets2.xml"
+                struct_map_locref_data[identifier] = build_descriptor_filename(resource)
 
         entity_template = template_env.get_template("preservation_mets.xml")
         for resource in self.resources:
@@ -31,7 +34,7 @@ class DescriptorGenerator:
                 action="stored",
                 create_date=datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
             )
-            filename = Path(f"descriptor/{resource.id}.{resource.type.lower()}.mets2.xml")
+            filename = Path(f"descriptor/{build_descriptor_filename(resource)}")
             with (self.package_path / filename).open("w") as f:
                 f.write(xmldata)
             self.entries.append(filename)

--- a/dor/service_layer/handlers/store_files.py
+++ b/dor/service_layer/handlers/store_files.py
@@ -18,7 +18,6 @@ def store_files(event: PackageUnpacked, uow: AbstractUnitOfWork, workspace_class
         source_bundle=bundle,
     )
 
-    #### INSERT HERE
     generator = DescriptorGenerator(
         package_path=workspace.object_data_directory(),
         resources=event.resources

--- a/dor/service_layer/handlers/store_files.py
+++ b/dor/service_layer/handlers/store_files.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from dor.domain.events import PackageStored, PackageUnpacked
 from dor.service_layer.unit_of_work import AbstractUnitOfWork
-
+from dor.providers.descriptor_generator import DescriptorGenerator
 
 def store_files(event: PackageUnpacked, uow: AbstractUnitOfWork, workspace_class: type) -> None:
     workspace = workspace_class(event.workspace_identifier, event.identifier)
@@ -17,6 +17,19 @@ def store_files(event: PackageUnpacked, uow: AbstractUnitOfWork, workspace_class
         id=event.identifier,
         source_bundle=bundle,
     )
+
+    #### INSERT HERE
+    generator = DescriptorGenerator(
+        package_path=workspace.object_data_directory(),
+        resources=event.resources
+    )
+    generator.write_files()
+    descriptor_bundle = workspace.get_bundle(generator.entries)
+    uow.gateway.stage_object_files(
+        id=event.identifier,
+        source_bundle=descriptor_bundle,
+    )
+
     uow.gateway.commit_object_changes(
         id=event.identifier,
         coordinator=event.version_info.coordinator,

--- a/templates/partials/_md_file_sec.fragment.xml
+++ b/templates/partials/_md_file_sec.fragment.xml
@@ -1,0 +1,9 @@
+{% if resource.data_files %}
+  <METS:fileSec>
+    {% for file in resource.data_files %}
+    <METS:file ID="{{ file.id }}" {% if file.group_id %}GROUPID="{{ file.group_id }}"{% endif %} USE="{{ file.use }}"  MIMETYPE="{{ file.ref.mimetype }}" MDID="{{ file.mdid }}">
+      <METS:FLocat LOCTYPE="SYSTEM" LOCREF="{{ file.ref.locref }}" />
+    </METS:file>
+    {% endfor %}
+  </METS:fileSec>
+{% endif %}

--- a/templates/partials/_md_file_sec.fragment.xml
+++ b/templates/partials/_md_file_sec.fragment.xml
@@ -2,7 +2,7 @@
   <METS:fileSec>
     {% for file in resource.data_files %}
     <METS:file ID="{{ file.id }}" {% if file.group_id %}GROUPID="{{ file.group_id }}"{% endif %} USE="{{ file.use }}"  MIMETYPE="{{ file.ref.mimetype }}" MDID="{{ file.mdid }}">
-      <METS:FLocat LOCTYPE="SYSTEM" LOCREF="../{{ file.ref.locref }}" />
+      <METS:FLocat LOCTYPE="SYSTEM" LOCREF="../{{ relative_path_or_not(file.ref.locref) }}" />
     </METS:file>
     {% endfor %}
   </METS:fileSec>

--- a/templates/partials/_md_file_sec.fragment.xml
+++ b/templates/partials/_md_file_sec.fragment.xml
@@ -2,7 +2,7 @@
   <METS:fileSec>
     {% for file in resource.data_files %}
     <METS:file ID="{{ file.id }}" {% if file.group_id %}GROUPID="{{ file.group_id }}"{% endif %} USE="{{ file.use }}"  MIMETYPE="{{ file.ref.mimetype }}" MDID="{{ file.mdid }}">
-      <METS:FLocat LOCTYPE="SYSTEM" LOCREF="{{ file.ref.locref }}" />
+      <METS:FLocat LOCTYPE="SYSTEM" LOCREF="../{{ file.ref.locref }}" />
     </METS:file>
     {% endfor %}
   </METS:fileSec>

--- a/templates/partials/_md_file_sec.fragment.xml
+++ b/templates/partials/_md_file_sec.fragment.xml
@@ -2,7 +2,7 @@
   <METS:fileSec>
     {% for file in resource.data_files %}
     <METS:file ID="{{ file.id }}" {% if file.group_id %}GROUPID="{{ file.group_id }}"{% endif %} USE="{{ file.use }}"  MIMETYPE="{{ file.ref.mimetype }}" MDID="{{ file.mdid }}">
-      <METS:FLocat LOCTYPE="SYSTEM" LOCREF="../{{ relative_path_or_not(file.ref.locref) }}" />
+      <METS:FLocat LOCTYPE="SYSTEM" LOCREF="{{ relative_path_or_not(file.ref.locref) }}" />
     </METS:file>
     {% endfor %}
   </METS:fileSec>

--- a/templates/partials/_md_sec.fragment.xml
+++ b/templates/partials/_md_sec.fragment.xml
@@ -1,0 +1,10 @@
+  {% if resource.metadata_files|length > 0 %}
+  <METS:mdSec>
+    {% for md in resource.metadata_files %}
+    <METS:md ID="{{ md.id }}" USE="{{ md.use }}">
+      <METS:mdRef LOCREF="{{ md.ref.locref }}" LOCTYPE="URL" MDTYPE="{{ md.ref.mdtype }}" {% if md.ref.mimetype %}MIMETYPE="{{ md.ref.mimetype }}"{% endif %} />
+    </METS:md>
+    {% endfor %}
+  </METS:mdSec>
+  {% endif %}
+  

--- a/templates/partials/_md_sec.fragment.xml
+++ b/templates/partials/_md_sec.fragment.xml
@@ -2,9 +2,8 @@
   <METS:mdSec>
     {% for md in resource.metadata_files %}
     <METS:md ID="{{ md.id }}" USE="{{ md.use }}">
-      <METS:mdRef LOCREF="{{ md.ref.locref }}" LOCTYPE="URL" MDTYPE="{{ md.ref.mdtype }}" {% if md.ref.mimetype %}MIMETYPE="{{ md.ref.mimetype }}"{% endif %} />
+      <METS:mdRef LOCREF="../{{ md.ref.locref }}" LOCTYPE="URL" MDTYPE="{{ md.ref.mdtype }}" {% if md.ref.mimetype %}MIMETYPE="{{ md.ref.mimetype }}"{% endif %} />
     </METS:md>
     {% endfor %}
   </METS:mdSec>
   {% endif %}
-  

--- a/templates/partials/_md_sec.fragment.xml
+++ b/templates/partials/_md_sec.fragment.xml
@@ -2,7 +2,7 @@
   <METS:mdSec>
     {% for md in resource.metadata_files %}
     <METS:md ID="{{ md.id }}" USE="{{ md.use }}">
-      <METS:mdRef LOCREF="../{{ md.ref.locref }}" LOCTYPE="URL" MDTYPE="{{ md.ref.mdtype }}" {% if md.ref.mimetype %}MIMETYPE="{{ md.ref.mimetype }}"{% endif %} />
+      <METS:mdRef LOCREF="{{ relative_path_or_not(md.ref.locref) }}" LOCTYPE="URL" MDTYPE="{{ md.ref.mdtype }}" {% if md.ref.mimetype %}MIMETYPE="{{ md.ref.mimetype }}"{% endif %} />
     </METS:md>
     {% endfor %}
   </METS:mdSec>

--- a/templates/partials/_struct_sec.fragment.xml
+++ b/templates/partials/_struct_sec.fragment.xml
@@ -1,0 +1,15 @@
+{% if resource.struct_maps|length > 0 %}
+  <METS:structSec>
+    {% for struct_map in resource.struct_maps %}
+    <METS:structMap ID="SM{{ loop.index }}" TYPE="{{ struct_map.type }}">
+      <METS:div>
+        {% for item in struct_map.items %}
+        <METS:div ORDERLABEL="{{ item.order }}" TYPE="{{ item.type }}" ORDER="{{ item.order }}" LABEL="{{ item.label }}" ID="{{ item.asset_id }}">
+          <METS:mptr LOCTYPE="URL" LOCREF="{{ asset_map[item.asset_id] }}" />
+        </METS:div>
+        {% endfor %}  
+      </METS:div>
+    </METS:structMap>
+    {% endfor %}
+  </METS:structSec>
+{% endif %}

--- a/templates/partials/_struct_sec.fragment.xml
+++ b/templates/partials/_struct_sec.fragment.xml
@@ -5,9 +5,9 @@
       <METS:div>
         {% for item in struct_map.items %}
         <METS:div ORDERLABEL="{{ item.order }}" TYPE="{{ item.type }}" ORDER="{{ item.order }}" LABEL="{{ item.label }}" ID="{{ item.asset_id }}">
-          <METS:mptr LOCTYPE="URL" LOCREF="{{ asset_map[item.asset_id] }}" />
+          <METS:mptr LOCTYPE="URL" LOCREF="{{ struct_map_locref_data[item.asset_id] }}" />
         </METS:div>
-        {% endfor %}  
+        {% endfor %}
       </METS:div>
     </METS:structMap>
     {% endfor %}

--- a/templates/preservation_mets.xml
+++ b/templates/preservation_mets.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<METS:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:METS="http://www.loc.gov/METS/v2" xmlns:PREMIS="http://www.loc.gov/premis/v3" xmlns:dcam="http://purl.org/dc/dcam/" OBJID="{{ object_identifier }}" xsi:schemaLocation="http://www.loc.gov/METS/v2 ../v2/mets.xsd http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd">
+
+  <METS:metsHdr RECORDSTATUS="{{ action }}" CREATEDATE="{{ create_date }}" ID="HDR1" TYPE="{{ resource.type }}">
+    <METS:agent ROLE="CREATOR" TYPE="ORGANIZATION">
+      <METS:name>University of Michigan - Library Information Technology - Digital Collection Services</METS:name>
+    </METS:agent>
+    {% if resource.alternate_identifier %}
+    <METS:altRecordID TYPE="{{ resource.alternate_identifier.type }}">{{ resource.alternate_identifier.id }}</METS:altRecordID>
+    {% endif %}
+  </METS:metsHdr>
+
+  {% include "partials/_md_sec.fragment.xml" %}
+
+  {% include "partials/_md_file_sec.fragment.xml" %}
+
+  {% include "partials/_struct_sec.fragment.xml" %}
+
+</METS:mets>

--- a/tests/test_descriptor_generator.py
+++ b/tests/test_descriptor_generator.py
@@ -172,12 +172,15 @@ def sample_resources():
     ]
 
 def test_generator_can_create_descriptor_files(sample_resources):
-    descriptor_path = Path("./tests/test_workspace/descriptor")
-    shutil.rmtree(descriptor_path, ignore_errors=True)
-    os.makedirs(descriptor_path)
+    package_path = Path("./tests/test_workspace")
+    shutil.rmtree(package_path, ignore_errors=True)
+    os.makedirs(package_path / "descriptor")
 
-    generator = DescriptorGenerator(output_path=descriptor_path, resources=sample_resources)
+    generator = DescriptorGenerator(package_path=package_path, resources=sample_resources)
     generator.write_files()
 
-    assert (descriptor_path / "00000000-0000-0000-0000-000000000001.monograph.mets2.xml" ).exists()
-    assert (descriptor_path / "00000000-0000-0000-0000-000000001001.asset.mets2.xml" ).exists()
+    assert (package_path / "descriptor" / "00000000-0000-0000-0000-000000000001.monograph.mets2.xml" ).exists()
+    assert (package_path / "descriptor" / "00000000-0000-0000-0000-000000001001.asset.mets2.xml" ).exists()
+
+def test_generator_can_return_entries_for_bundle(sample_resources):
+    assert True

--- a/tests/test_descriptor_generator.py
+++ b/tests/test_descriptor_generator.py
@@ -182,7 +182,7 @@ def test_generator_can_create_descriptor_files(sample_resources):
     assert (package_path / "descriptor" / "00000000-0000-0000-0000-000000000001.monograph.mets2.xml" ).exists()
     assert (package_path / "descriptor" / "00000000-0000-0000-0000-000000001001.asset.mets2.xml" ).exists()
 
-def test_generator_can_return_entries_for_bundle(sample_resources):
+def test_generator_can_return_entries(sample_resources):
     package_path = Path("./tests/test_workspace")
     shutil.rmtree(package_path, ignore_errors=True)
     os.makedirs(package_path / "descriptor")

--- a/tests/test_descriptor_generator.py
+++ b/tests/test_descriptor_generator.py
@@ -194,7 +194,7 @@ def test_generator_can_create_descriptor_files(sample_bin):
     os.makedirs(descriptor_path)
 
     generator = DescriptorGenerator(output_path=descriptor_path, bin=sample_bin)
-    filenames = generator.write_files()
+    generator.write_files()
 
-    for filename in filenames:
-        assert filename.exists()
+    assert (descriptor_path / "00000000-0000-0000-0000-000000000001.monograph.mets2.xml" ).exists()
+    assert (descriptor_path / "00000000-0000-0000-0000-000000001001.asset.mets2.xml" ).exists()

--- a/tests/test_descriptor_generator.py
+++ b/tests/test_descriptor_generator.py
@@ -187,8 +187,6 @@ def sample_bin():
     )
 
 def test_generator_can_create_descriptor_files(sample_bin):
-    # identifier = '00000000-0000-0000-0000-000000000001'
-
     descriptor_path = Path("./tests/test_workspace/descriptor")
     shutil.rmtree(descriptor_path, ignore_errors=True)
     os.makedirs(descriptor_path)

--- a/tests/test_descriptor_generator.py
+++ b/tests/test_descriptor_generator.py
@@ -183,4 +183,15 @@ def test_generator_can_create_descriptor_files(sample_resources):
     assert (package_path / "descriptor" / "00000000-0000-0000-0000-000000001001.asset.mets2.xml" ).exists()
 
 def test_generator_can_return_entries_for_bundle(sample_resources):
-    assert True
+    package_path = Path("./tests/test_workspace")
+    shutil.rmtree(package_path, ignore_errors=True)
+    os.makedirs(package_path / "descriptor")
+
+    generator = DescriptorGenerator(package_path=package_path, resources=sample_resources)
+    generator.write_files()
+
+    entries = generator.entries
+    assert entries == [
+        Path("descriptor/00000000-0000-0000-0000-000000000001.monograph.mets2.xml"),
+        Path("descriptor/00000000-0000-0000-0000-000000001001.asset.mets2.xml")
+    ]

--- a/tests/test_descriptor_generator.py
+++ b/tests/test_descriptor_generator.py
@@ -1,0 +1,200 @@
+import os
+import shutil
+from pathlib import Path
+import uuid
+import pytest
+from datetime import datetime, UTC
+
+from dor.domain.models import Bin
+from dor.providers.models import (
+    Agent,
+    AlternateIdentifier,
+    FileMetadata,
+    FileReference,
+    PackageResource,
+    PreservationEvent,
+    StructMap,
+    StructMapItem,
+    StructMapType,
+)
+
+from dor.providers.translocator import Workspace
+from dor.providers.descriptor_generator import DescriptorGenerator
+
+@pytest.fixture
+def sample_bin():
+    return Bin(
+        identifier=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        alternate_identifiers=["xyzzy:00000001"],
+        common_metadata={
+            "@schema": "urn:umich.edu:dor:schema:common",
+            "title": "Discussion also Republican owner hot already itself.",
+            "author": "Kimberly Garza",
+            "publication_date": "1989-04-16",
+            "subjects": [
+                "Liechtenstein",
+                "Vietnam",
+            ]
+        },
+        package_resources=[
+            PackageResource(
+                id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+                type="Monograph",
+                alternate_identifier=AlternateIdentifier(id="xyzzy:00000001", type="DLXS"),
+                events=[
+                    PreservationEvent(
+                        identifier="abdcb901-721a-4be0-a981-14f514236633",
+                        type="ingest",
+                        datetime=datetime(2016, 11, 29, 13, 51, 14, tzinfo=UTC),
+                        detail="Middle president push visit information feel most.",
+                        agent=Agent(
+                            address="christopherpayne@example.org", role="collection manager"
+                        ),
+                    )
+                ],
+                metadata_files=[
+                    FileMetadata(
+                        id="_0193d5f0-7f64-7ac8-8f94-85c55c7313e4",
+                        use="DESCRIPTIVE/COMMON",
+                        ref=FileReference(
+                            locref="../metadata/00000000-0000-0000-0000-000000000001.common.json",
+                            mdtype="DOR:SCHEMA",
+                            mimetype="application/json",
+                        ),
+                    ),
+                    FileMetadata(
+                        id="_0193d5f0-7f65-783e-b7b4-485b6f6b24d0",
+                        use="DESCRIPTIVE",
+                        ref=FileReference(
+                            locref="../metadata/00000000-0000-0000-0000-000000000001.metadata.json",
+                            mdtype="DOR:SCHEMA",
+                            mimetype="application/json",
+                        ),
+                    ),
+                    FileMetadata(
+                        id="RIGHTS1",
+                        use="RIGHTS",
+                        ref=FileReference(
+                            locref="https://creativecommons.org/publicdomain/zero/1.0/",
+                            mdtype="OTHER",
+                        ),
+                    ),
+                ],
+                struct_maps=[
+                    StructMap(
+                        id="SM1",
+                        type=StructMapType.PHYSICAL,
+                        items=[
+                            StructMapItem(
+                                order=1,
+                                type="page",
+                                label="Page 1",
+                                asset_id="urn:dor:00000000-0000-0000-0000-000000001001",
+                            ),
+                            StructMapItem(
+                                order=2,
+                                type="page",
+                                label="Page 2",
+                                asset_id="urn:dor:00000000-0000-0000-0000-000000001002",
+                            ),
+                        ],
+                    )
+                ],
+            ),
+            PackageResource(
+                id=uuid.UUID("00000000-0000-0000-0000-000000001001"),
+                type="Asset",
+                alternate_identifier=AlternateIdentifier(
+                    id="xyzzy:00000001:00000001", type="DLXS"
+                ),
+                events=[
+                    PreservationEvent(
+                        identifier="fe4c76e5-dbf1-4934-97fb-52ef5a68f073",
+                        type="generate access derivative",
+                        datetime=datetime(1993, 6, 11, 4, 44, 7, tzinfo=UTC),
+                        detail="Night wonder three him family structure simple.",
+                        agent=Agent(address="arroyoalan@example.net", role="image processing"),
+                    ),
+                    PreservationEvent(
+                        identifier="3bdcb1e3-4674-4b9c-83c8-4f9f9fe50812",
+                        type="extract text",
+                        datetime=datetime(1988, 5, 26, 18, 33, 46, tzinfo=UTC),
+                        detail="Player center road attorney speak wait partner.",
+                        agent=Agent(address="jonathanjones@example.net", role="ocr processing"),
+                    ),
+                ],
+                metadata_files=[
+                    FileMetadata(
+                        id="_0193d5f0-7e72-7481-b6fd-0f916c30b396",
+                        use="TECHNICAL",
+                        ref=FileReference(
+                            locref="../metadata/00000001.source.jpg.mix.xml",
+                            mdtype="NISOIMG",
+                        ),
+                    ),
+                    FileMetadata(
+                        id="_0193d5f0-7e75-7803-8e41-71323b7b3284",
+                        group_id="_0193d5f0-7e72-7481-b6fd-0f916c30b396",
+                        use="TECHNICAL",
+                        ref=FileReference(
+                            locref="../metadata/00000001.access.jpg.mix.xml",
+                            mdtype="NISOIMG",
+                        ),
+                    ),
+                    FileMetadata(
+                        id="_0193d5f0-7f54-7268-b9b1-821085acdcf7",
+                        group_id="_0193d5f0-7e72-7481-b6fd-0f916c30b396",
+                        use="TECHNICAL",
+                        ref=FileReference(
+                            locref="../metadata/00000001.plaintext.txt.textmd.xml",
+                            mdtype="TEXTMD",
+                        ),
+                    ),
+                ],
+                data_files=[
+                    FileMetadata(
+                        id="_be653ff450ae7f3520312a53e56c00bc",
+                        mdid="_0193d5f0-7e72-7481-b6fd-0f916c30b396",
+                        use="SOURCE",
+                        ref=FileReference(
+                            locref="../data/00000001.source.jpg",
+                            mimetype="image/jpeg",
+                        ),
+                    ),
+                    FileMetadata(
+                        id="_7e923d9c33b3859e1327fa53a8e609a1",
+                        groupid="_be653ff450ae7f3520312a53e56c00bc",
+                        mdid="_0193d5f0-7e75-7803-8e41-71323b7b3284",
+                        use="ACCESS",
+                        ref=FileReference(
+                            locref="../data/00000001.access.jpg",
+                            mimetype="image/jpeg",
+                        ),
+                    ),
+                    FileMetadata(
+                        id="_764ba9761fbc6cbf0462d28d19356148",
+                        groupid="_be653ff450ae7f3520312a53e56c00bc",
+                        mdid="_0193d5f0-7f54-7268-b9b1-821085acdcf7",
+                        use="SOURCE",
+                        ref=FileReference(
+                            locref="../data/00000001.plaintext.txt",
+                            mimetype="text/plain",
+                        ),
+                    ),
+                ],
+            )
+        ]
+    )
+
+def test_generator_can_create_descriptor_files(sample_bin):
+    # identifier = '00000000-0000-0000-0000-000000000001'
+
+    descriptor_path = Path("./tests/test_workspace/descriptor")
+    shutil.rmtree(descriptor_path, ignore_errors=True)
+    os.makedirs(descriptor_path)
+
+    generator = DescriptorGenerator(output_path=descriptor_path, bin=sample_bin)
+    filenames = generator.write_files()
+
+    for filename in filenames:
+        assert filename.exists()

--- a/tests/test_descriptor_generator.py
+++ b/tests/test_descriptor_generator.py
@@ -5,7 +5,6 @@ import uuid
 import pytest
 from datetime import datetime, UTC
 
-from dor.domain.models import Bin
 from dor.providers.models import (
     Agent,
     AlternateIdentifier,
@@ -22,176 +21,162 @@ from dor.providers.translocator import Workspace
 from dor.providers.descriptor_generator import DescriptorGenerator
 
 @pytest.fixture
-def sample_bin():
-    return Bin(
-        identifier=uuid.UUID("00000000-0000-0000-0000-000000000001"),
-        alternate_identifiers=["xyzzy:00000001"],
-        common_metadata={
-            "@schema": "urn:umich.edu:dor:schema:common",
-            "title": "Discussion also Republican owner hot already itself.",
-            "author": "Kimberly Garza",
-            "publication_date": "1989-04-16",
-            "subjects": [
-                "Liechtenstein",
-                "Vietnam",
-            ]
-        },
-        package_resources=[
-            PackageResource(
-                id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
-                type="Monograph",
-                alternate_identifier=AlternateIdentifier(id="xyzzy:00000001", type="DLXS"),
-                events=[
-                    PreservationEvent(
-                        identifier="abdcb901-721a-4be0-a981-14f514236633",
-                        type="ingest",
-                        datetime=datetime(2016, 11, 29, 13, 51, 14, tzinfo=UTC),
-                        detail="Middle president push visit information feel most.",
-                        agent=Agent(
-                            address="christopherpayne@example.org", role="collection manager"
-                        ),
-                    )
-                ],
-                metadata_files=[
-                    FileMetadata(
-                        id="_0193d5f0-7f64-7ac8-8f94-85c55c7313e4",
-                        use="DESCRIPTIVE/COMMON",
-                        ref=FileReference(
-                            locref="../metadata/00000000-0000-0000-0000-000000000001.common.json",
-                            mdtype="DOR:SCHEMA",
-                            mimetype="application/json",
-                        ),
+def sample_resources():
+    return [
+        PackageResource(
+            id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+            type="Monograph",
+            alternate_identifier=AlternateIdentifier(id="xyzzy:00000001", type="DLXS"),
+            events=[
+                PreservationEvent(
+                    identifier="abdcb901-721a-4be0-a981-14f514236633",
+                    type="ingest",
+                    datetime=datetime(2016, 11, 29, 13, 51, 14, tzinfo=UTC),
+                    detail="Middle president push visit information feel most.",
+                    agent=Agent(
+                        address="christopherpayne@example.org", role="collection manager"
                     ),
-                    FileMetadata(
-                        id="_0193d5f0-7f65-783e-b7b4-485b6f6b24d0",
-                        use="DESCRIPTIVE",
-                        ref=FileReference(
-                            locref="../metadata/00000000-0000-0000-0000-000000000001.metadata.json",
-                            mdtype="DOR:SCHEMA",
-                            mimetype="application/json",
-                        ),
+                )
+            ],
+            metadata_files=[
+                FileMetadata(
+                    id="_0193d5f0-7f64-7ac8-8f94-85c55c7313e4",
+                    use="DESCRIPTIVE/COMMON",
+                    ref=FileReference(
+                        locref="../metadata/00000000-0000-0000-0000-000000000001.common.json",
+                        mdtype="DOR:SCHEMA",
+                        mimetype="application/json",
                     ),
-                    FileMetadata(
-                        id="RIGHTS1",
-                        use="RIGHTS",
-                        ref=FileReference(
-                            locref="https://creativecommons.org/publicdomain/zero/1.0/",
-                            mdtype="OTHER",
-                        ),
-                    ),
-                ],
-                struct_maps=[
-                    StructMap(
-                        id="SM1",
-                        type=StructMapType.PHYSICAL,
-                        items=[
-                            StructMapItem(
-                                order=1,
-                                type="page",
-                                label="Page 1",
-                                asset_id="urn:dor:00000000-0000-0000-0000-000000001001",
-                            ),
-                            StructMapItem(
-                                order=2,
-                                type="page",
-                                label="Page 2",
-                                asset_id="urn:dor:00000000-0000-0000-0000-000000001002",
-                            ),
-                        ],
-                    )
-                ],
-            ),
-            PackageResource(
-                id=uuid.UUID("00000000-0000-0000-0000-000000001001"),
-                type="Asset",
-                alternate_identifier=AlternateIdentifier(
-                    id="xyzzy:00000001:00000001", type="DLXS"
                 ),
-                events=[
-                    PreservationEvent(
-                        identifier="fe4c76e5-dbf1-4934-97fb-52ef5a68f073",
-                        type="generate access derivative",
-                        datetime=datetime(1993, 6, 11, 4, 44, 7, tzinfo=UTC),
-                        detail="Night wonder three him family structure simple.",
-                        agent=Agent(address="arroyoalan@example.net", role="image processing"),
+                FileMetadata(
+                    id="_0193d5f0-7f65-783e-b7b4-485b6f6b24d0",
+                    use="DESCRIPTIVE",
+                    ref=FileReference(
+                        locref="../metadata/00000000-0000-0000-0000-000000000001.metadata.json",
+                        mdtype="DOR:SCHEMA",
+                        mimetype="application/json",
                     ),
-                    PreservationEvent(
-                        identifier="3bdcb1e3-4674-4b9c-83c8-4f9f9fe50812",
-                        type="extract text",
-                        datetime=datetime(1988, 5, 26, 18, 33, 46, tzinfo=UTC),
-                        detail="Player center road attorney speak wait partner.",
-                        agent=Agent(address="jonathanjones@example.net", role="ocr processing"),
+                ),
+                FileMetadata(
+                    id="RIGHTS1",
+                    use="RIGHTS",
+                    ref=FileReference(
+                        locref="https://creativecommons.org/publicdomain/zero/1.0/",
+                        mdtype="OTHER",
                     ),
-                ],
-                metadata_files=[
-                    FileMetadata(
-                        id="_0193d5f0-7e72-7481-b6fd-0f916c30b396",
-                        use="TECHNICAL",
-                        ref=FileReference(
-                            locref="../metadata/00000001.source.jpg.mix.xml",
-                            mdtype="NISOIMG",
+                ),
+            ],
+            struct_maps=[
+                StructMap(
+                    id="SM1",
+                    type=StructMapType.PHYSICAL,
+                    items=[
+                        StructMapItem(
+                            order=1,
+                            type="page",
+                            label="Page 1",
+                            asset_id="urn:dor:00000000-0000-0000-0000-000000001001",
                         ),
-                    ),
-                    FileMetadata(
-                        id="_0193d5f0-7e75-7803-8e41-71323b7b3284",
-                        group_id="_0193d5f0-7e72-7481-b6fd-0f916c30b396",
-                        use="TECHNICAL",
-                        ref=FileReference(
-                            locref="../metadata/00000001.access.jpg.mix.xml",
-                            mdtype="NISOIMG",
+                        StructMapItem(
+                            order=2,
+                            type="page",
+                            label="Page 2",
+                            asset_id="urn:dor:00000000-0000-0000-0000-000000001002",
                         ),
+                    ],
+                )
+            ],
+        ),
+        PackageResource(
+            id=uuid.UUID("00000000-0000-0000-0000-000000001001"),
+            type="Asset",
+            alternate_identifier=AlternateIdentifier(
+                id="xyzzy:00000001:00000001", type="DLXS"
+            ),
+            events=[
+                PreservationEvent(
+                    identifier="fe4c76e5-dbf1-4934-97fb-52ef5a68f073",
+                    type="generate access derivative",
+                    datetime=datetime(1993, 6, 11, 4, 44, 7, tzinfo=UTC),
+                    detail="Night wonder three him family structure simple.",
+                    agent=Agent(address="arroyoalan@example.net", role="image processing"),
+                ),
+                PreservationEvent(
+                    identifier="3bdcb1e3-4674-4b9c-83c8-4f9f9fe50812",
+                    type="extract text",
+                    datetime=datetime(1988, 5, 26, 18, 33, 46, tzinfo=UTC),
+                    detail="Player center road attorney speak wait partner.",
+                    agent=Agent(address="jonathanjones@example.net", role="ocr processing"),
+                ),
+            ],
+            metadata_files=[
+                FileMetadata(
+                    id="_0193d5f0-7e72-7481-b6fd-0f916c30b396",
+                    use="TECHNICAL",
+                    ref=FileReference(
+                        locref="../metadata/00000001.source.jpg.mix.xml",
+                        mdtype="NISOIMG",
                     ),
-                    FileMetadata(
-                        id="_0193d5f0-7f54-7268-b9b1-821085acdcf7",
-                        group_id="_0193d5f0-7e72-7481-b6fd-0f916c30b396",
-                        use="TECHNICAL",
-                        ref=FileReference(
-                            locref="../metadata/00000001.plaintext.txt.textmd.xml",
-                            mdtype="TEXTMD",
-                        ),
+                ),
+                FileMetadata(
+                    id="_0193d5f0-7e75-7803-8e41-71323b7b3284",
+                    group_id="_0193d5f0-7e72-7481-b6fd-0f916c30b396",
+                    use="TECHNICAL",
+                    ref=FileReference(
+                        locref="../metadata/00000001.access.jpg.mix.xml",
+                        mdtype="NISOIMG",
                     ),
-                ],
-                data_files=[
-                    FileMetadata(
-                        id="_be653ff450ae7f3520312a53e56c00bc",
-                        mdid="_0193d5f0-7e72-7481-b6fd-0f916c30b396",
-                        use="SOURCE",
-                        ref=FileReference(
-                            locref="../data/00000001.source.jpg",
-                            mimetype="image/jpeg",
-                        ),
+                ),
+                FileMetadata(
+                    id="_0193d5f0-7f54-7268-b9b1-821085acdcf7",
+                    group_id="_0193d5f0-7e72-7481-b6fd-0f916c30b396",
+                    use="TECHNICAL",
+                    ref=FileReference(
+                        locref="../metadata/00000001.plaintext.txt.textmd.xml",
+                        mdtype="TEXTMD",
                     ),
-                    FileMetadata(
-                        id="_7e923d9c33b3859e1327fa53a8e609a1",
-                        groupid="_be653ff450ae7f3520312a53e56c00bc",
-                        mdid="_0193d5f0-7e75-7803-8e41-71323b7b3284",
-                        use="ACCESS",
-                        ref=FileReference(
-                            locref="../data/00000001.access.jpg",
-                            mimetype="image/jpeg",
-                        ),
+                ),
+            ],
+            data_files=[
+                FileMetadata(
+                    id="_be653ff450ae7f3520312a53e56c00bc",
+                    mdid="_0193d5f0-7e72-7481-b6fd-0f916c30b396",
+                    use="SOURCE",
+                    ref=FileReference(
+                        locref="../data/00000001.source.jpg",
+                        mimetype="image/jpeg",
                     ),
-                    FileMetadata(
-                        id="_764ba9761fbc6cbf0462d28d19356148",
-                        groupid="_be653ff450ae7f3520312a53e56c00bc",
-                        mdid="_0193d5f0-7f54-7268-b9b1-821085acdcf7",
-                        use="SOURCE",
-                        ref=FileReference(
-                            locref="../data/00000001.plaintext.txt",
-                            mimetype="text/plain",
-                        ),
+                ),
+                FileMetadata(
+                    id="_7e923d9c33b3859e1327fa53a8e609a1",
+                    groupid="_be653ff450ae7f3520312a53e56c00bc",
+                    mdid="_0193d5f0-7e75-7803-8e41-71323b7b3284",
+                    use="ACCESS",
+                    ref=FileReference(
+                        locref="../data/00000001.access.jpg",
+                        mimetype="image/jpeg",
                     ),
-                ],
-            )
-        ]
-    )
+                ),
+                FileMetadata(
+                    id="_764ba9761fbc6cbf0462d28d19356148",
+                    groupid="_be653ff450ae7f3520312a53e56c00bc",
+                    mdid="_0193d5f0-7f54-7268-b9b1-821085acdcf7",
+                    use="SOURCE",
+                    ref=FileReference(
+                        locref="../data/00000001.plaintext.txt",
+                        mimetype="text/plain",
+                    ),
+                ),
+            ],
+        )
+    ]
 
-def test_generator_can_create_descriptor_files(sample_bin):
+def test_generator_can_create_descriptor_files(sample_resources):
     descriptor_path = Path("./tests/test_workspace/descriptor")
     shutil.rmtree(descriptor_path, ignore_errors=True)
     os.makedirs(descriptor_path)
 
-    generator = DescriptorGenerator(output_path=descriptor_path, bin=sample_bin)
+    generator = DescriptorGenerator(output_path=descriptor_path, resources=sample_resources)
     generator.write_files()
 
     assert (descriptor_path / "00000000-0000-0000-0000-000000000001.monograph.mets2.xml" ).exists()


### PR DESCRIPTION
Generates preservation descriptor files during the `store_files` handler.

At present, only metadata described via `mdRef` are written to these files. Metadata described in `mdWrap` blocks (PREMIS and collection metadata) is **not** written out: this was a deliberate choice reflecting that the METS structure will be evolving.

