### PR TITLE
Introduce `WorkflowEvent` and `EventStore` for workflow tracking

### DIFF
--- a/dor/adapters/catalog.py
+++ b/dor/adapters/catalog.py
@@ -1,36 +1,18 @@
-# from dor.domain.models import Bin
-from abc import ABC, abstractmethod
-from dor.domain import models
-
 import uuid
+from abc import ABC, abstractmethod
 
-from sqlalchemy.dialects.postgresql import JSONB, ARRAY
+import sqlalchemy.exc
 from sqlalchemy import (
-    Column, String, select, Table, Uuid
+    Column, String, select, Uuid
 )
-from sqlalchemy.orm import registry
-
-from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.dialects.postgresql import JSONB, ARRAY
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
 from sqlalchemy.ext.mutable import MutableList
-import sqlalchemy.exc
 
-from pydantic_core import to_jsonable_python
-import json
+from dor.adapters.sqlalchemy import Base
+from dor.domain import models
 
-from dor.providers.models import PackageResource
-
-mapper_registry = registry()
-
-def _custom_json_serializer(*args, **kwargs) -> str:
-    """
-    Encodes json in the same way that pydantic does.
-    """
-    return json.dumps(*args, default=to_jsonable_python, **kwargs)
-
-class Base(DeclarativeBase):
-    pass
 
 class Bin(Base):
     __tablename__ = "catalog_bin"

--- a/dor/adapters/event_store.py
+++ b/dor/adapters/event_store.py
@@ -31,10 +31,11 @@ class MemoryEventStore(EventStore):
         self.events.append(event)
 
     def get_all_by_tracking_identifier(self, tracking_identifier: str) -> list[models.WorkflowEvent]:
-        return [
+        workflow_events = [
             event for event in self.events
             if event.tracking_identifier == tracking_identifier
         ]
+        return sorted(workflow_events, key=lambda x: x.timestamp, reverse=True)
 
 
 class WorkflowEvent(Base):
@@ -53,8 +54,9 @@ class SqlalchemyEventStore(EventStore):
     def __init__(self, session):
         self.session = session
 
-    def add(self, event: models.WorkflowEvent) -> None:
-        stored_event = WorkflowEvent(
+    @staticmethod
+    def _convert_domain_to_orm(event: models.WorkflowEvent) -> WorkflowEvent:
+        return WorkflowEvent(
             identifier=event.identifier,
             package_identifier=event.package_identifier,
             tracking_identifier=event.tracking_identifier,
@@ -62,23 +64,29 @@ class SqlalchemyEventStore(EventStore):
             timestamp=event.timestamp,
             message=event.message
         )
+
+    @staticmethod
+    def _convert_orm_to_domain(event: WorkflowEvent) -> models.WorkflowEvent:
+        return models.WorkflowEvent(
+            identifier=event.identifier,
+            package_identifier=event.package_identifier,
+            tracking_identifier=event.tracking_identifier,
+            event_type=models.WorkflowEventType(event.event_type),
+            timestamp=event.timestamp,
+            message=event.message
+        )
+
+    def add(self, event: models.WorkflowEvent) -> None:
+        stored_event = self._convert_domain_to_orm(event)
         self.session.add(stored_event)
 
     def get_all_by_tracking_identifier(self, tracking_identifier: str) -> list[models.WorkflowEvent]:
         statement = select(WorkflowEvent).where(
             WorkflowEvent.tracking_identifier == tracking_identifier
-        )
+        ).order_by(WorkflowEvent.timestamp.desc())
+
         results = self.session.scalars(statement).all()
         events = []
         for result in results:
-            events.append(
-                models.WorkflowEvent(
-                    identifier=result.identifier,
-                    package_identifier=result.package_identifier,
-                    tracking_identifier=result.tracking_identifier,
-                    event_type=models.WorkflowEventType(result.event_type),
-                    timestamp=result.timestamp,
-                    message=result.message
-                )
-            )
+            events.append(self._convert_orm_to_domain(result))
         return events

--- a/dor/adapters/event_store.py
+++ b/dor/adapters/event_store.py
@@ -1,0 +1,84 @@
+import uuid
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, String, select, Uuid
+from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import mapped_column
+
+from dor.domain import models
+from dor.adapters.catalog import Base
+
+
+class EventStore(ABC):
+
+    @abstractmethod
+    def add(self, event: models.WorkflowEvent):
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_all_by_tracking_identifier(self, tracking_identifier: str) -> list[models.WorkflowEvent]:
+        raise NotImplementedError
+
+
+class MemoryEventStore(EventStore):
+
+    def __init__(self):
+        self.events: list[models.WorkflowEvent] = []
+
+    def add(self, event: models.WorkflowEvent) -> None:
+        self.events.append(event)
+
+    def get_all_by_tracking_identifier(self, tracking_identifier: str) -> list[models.WorkflowEvent]:
+        return [
+            event for event in self.events
+            if event.tracking_identifier == tracking_identifier
+        ]
+
+
+class WorkflowEvent(Base):
+    __tablename__ = "workflow_event"
+
+    identifier: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True)
+    package_identifier: Mapped[str] = mapped_column(String(30))
+    tracking_identifier: Mapped[str] = mapped_column(String(30))
+    event_type: Mapped[str] = mapped_column(String(30))
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    message: Mapped[Optional[str]] = mapped_column(String(1000))
+
+
+class SqlalchemyEventStore(EventStore):
+
+    def __init__(self, session):
+        self.session = session
+
+    def add(self, event: models.WorkflowEvent) -> None:
+        stored_event = WorkflowEvent(
+            identifier=event.identifier,
+            package_identifier=event.package_identifier,
+            tracking_identifier=event.tracking_identifier,
+            event_type=event.event_type.value,
+            timestamp=event.timestamp,
+            message=event.message
+        )
+        self.session.add(stored_event)
+
+    def get_all_by_tracking_identifier(self, tracking_identifier: str) -> list[models.WorkflowEvent]:
+        statement = select(WorkflowEvent).where(
+            WorkflowEvent.tracking_identifier == tracking_identifier
+        )
+        results = self.session.scalars(statement).all()
+        events = []
+        for result in results:
+            events.append(
+                models.WorkflowEvent(
+                    identifier=result.identifier,
+                    package_identifier=result.package_identifier,
+                    tracking_identifier=result.tracking_identifier,
+                    event_type=models.WorkflowEventType(result.event_type),
+                    timestamp=result.timestamp,
+                    message=result.message
+                )
+            )
+        return events

--- a/dor/adapters/event_store.py
+++ b/dor/adapters/event_store.py
@@ -41,9 +41,9 @@ class WorkflowEvent(Base):
     __tablename__ = "workflow_event"
 
     identifier: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True)
-    package_identifier: Mapped[str] = mapped_column(String(30))
-    tracking_identifier: Mapped[str] = mapped_column(String(30))
-    event_type: Mapped[str] = mapped_column(String(30))
+    package_identifier: Mapped[str] = mapped_column(String(50))
+    tracking_identifier: Mapped[str] = mapped_column(String(50))
+    event_type: Mapped[str] = mapped_column(String(50))
     timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     message: Mapped[Optional[str]] = mapped_column(String(1000))
 

--- a/dor/adapters/event_store.py
+++ b/dor/adapters/event_store.py
@@ -7,8 +7,8 @@ from sqlalchemy import DateTime, String, select, Uuid
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
 
+from dor.adapters.sqlalchemy import Base
 from dor.domain import models
-from dor.adapters.catalog import Base
 
 
 class EventStore(ABC):

--- a/dor/adapters/event_store.py
+++ b/dor/adapters/event_store.py
@@ -18,7 +18,7 @@ class EventStore(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_all_by_tracking_identifier(self, tracking_identifier: str) -> list[models.WorkflowEvent]:
+    def get_all_for_tracking_identifier(self, tracking_identifier: str) -> list[models.WorkflowEvent]:
         raise NotImplementedError
 
 
@@ -30,7 +30,7 @@ class MemoryEventStore(EventStore):
     def add(self, event: models.WorkflowEvent) -> None:
         self.events.append(event)
 
-    def get_all_by_tracking_identifier(self, tracking_identifier: str) -> list[models.WorkflowEvent]:
+    def get_all_for_tracking_identifier(self, tracking_identifier: str) -> list[models.WorkflowEvent]:
         workflow_events = [
             event for event in self.events
             if event.tracking_identifier == tracking_identifier
@@ -80,7 +80,7 @@ class SqlalchemyEventStore(EventStore):
         stored_event = self._convert_domain_to_orm(event)
         self.session.add(stored_event)
 
-    def get_all_by_tracking_identifier(self, tracking_identifier: str) -> list[models.WorkflowEvent]:
+    def get_all_for_tracking_identifier(self, tracking_identifier: str) -> list[models.WorkflowEvent]:
         statement = select(WorkflowEvent).where(
             WorkflowEvent.tracking_identifier == tracking_identifier
         ).order_by(WorkflowEvent.timestamp.desc())

--- a/dor/adapters/sqlalchemy.py
+++ b/dor/adapters/sqlalchemy.py
@@ -1,0 +1,15 @@
+import json
+
+from pydantic_core import to_jsonable_python
+from sqlalchemy.orm import DeclarativeBase
+
+
+def _custom_json_serializer(*args, **kwargs) -> str:
+    """
+    Encodes json in the same way that pydantic does.
+    """
+    return json.dumps(*args, default=to_jsonable_python, **kwargs)
+
+
+class Base(DeclarativeBase):
+    pass

--- a/dor/cli/repo.py
+++ b/dor/cli/repo.py
@@ -43,12 +43,13 @@ def bootstrap() -> Tuple[MemoryMessageBus, SqlalchemyUnitOfWork]:
     session_factory = sessionmaker(bind=engine)
     uow = SqlalchemyUnitOfWork(gateway=gateway, session_factory=session_factory)
 
+    file_provider = FilesystemFileProvider()
     translocator = Translocator(
         inbox_path=config.inbox_path,
         workspaces_path=config.workspaces_path,
-        minter = lambda: str(uuid.uuid4())
+        minter=lambda: str(uuid.uuid4()),
+        file_provider=file_provider
     )
-    file_provider = FilesystemFileProvider()
 
     handlers: dict[Type[Event], list[Callable]] = {
         PackageSubmitted: [

--- a/dor/cli/repo.py
+++ b/dor/cli/repo.py
@@ -6,7 +6,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from dor.adapters.bag_adapter import BagAdapter
-from dor.adapters.catalog import Base, _custom_json_serializer
+from dor.adapters.sqlalchemy import Base, _custom_json_serializer
 from dor.config import config
 from dor.domain.events import (
     Event,

--- a/dor/domain/events.py
+++ b/dor/domain/events.py
@@ -11,48 +11,43 @@ class Event:
 
 
 @dataclass
-class PackageSubmitted(Event):
+class PackageEvent(Event):
     package_identifier: str
+    tracking_identifier: str
 
 
 @dataclass
-class PackageReceived(Event):
-    package_identifier: str
-    tracking_identifier: str
+class PackageSubmitted(PackageEvent):
+    pass
+
+@dataclass
+class PackageReceived(PackageEvent):
     workspace_identifier: str
 
 
 @dataclass
-class PackageVerified(Event):
-    package_identifier: str
-    tracking_identifier: str
+class PackageVerified(PackageEvent):
     workspace_identifier: str
 
 
 @dataclass
-class PackageNotVerified(Event):
-    package_identifier: str
-    tracking_identifier: str
+class PackageNotVerified(PackageEvent):
     message: str
 
 
 @dataclass
-class PackageUnpacked(Event):
+class PackageUnpacked(PackageEvent):
     identifier: str
     resources: list[PackageResource]
-    tracking_identifier: str
     version_info: VersionInfo
     workspace_identifier: str
-    package_identifier: str
 
 
 @dataclass
-class PackageStored(Event):
+class PackageStored(PackageEvent):
     identifier: str
-    tracking_identifier: str
     resources: list[PackageResource]
 
 @dataclass
-class BinCataloged(Event):
+class BinCataloged(PackageEvent):
     identifier: str
-    tracking_identifier: str

--- a/dor/domain/models.py
+++ b/dor/domain/models.py
@@ -1,10 +1,10 @@
 import uuid
-# from dataclasses import dataclass, field
-from dataclasses import field
+from enum import Enum
+from datetime import datetime
+from typing import Any
+
 from pydantic import field_validator
 from pydantic.dataclasses import dataclass
-
-from typing import Any
 
 from gateway.coordinator import Coordinator
 from dor.providers.models import PackageResource
@@ -27,3 +27,23 @@ class Bin:
     @classmethod
     def coerce_to_instance(cls, values):
         return [PackageResource(**v) if isinstance(v, dict) else v for v in values]
+
+
+class WorkflowEventType(Enum):
+    PACKAGE_SUBMITTED = "PackageSubmitted"
+    PACKAGE_RECEIVED = "PackageReceived"
+    PACKAGE_VERIFIED = "PackageVerified"
+    PACKAGE_NOT_VERIFIED = "PackageNotVerified"
+    PACKAGE_UNPACKED = "PackageUnpacked"
+    PACKAGE_STORED = "PackageStored"
+    BIN_CATALOGED = "BinCataloged"
+
+
+@dataclass
+class WorkflowEvent:
+    identifier: uuid.UUID
+    package_identifier: str
+    tracking_identifier: str
+    event_type: WorkflowEventType
+    timestamp: datetime
+    message: str | None

--- a/dor/domain/models.py
+++ b/dor/domain/models.py
@@ -1,6 +1,6 @@
 import uuid
 from enum import Enum
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Any
 
 from pydantic import field_validator
@@ -47,3 +47,20 @@ class WorkflowEvent:
     event_type: WorkflowEventType
     timestamp: datetime
     message: str | None
+
+    @classmethod
+    def create(
+        cls,
+        package_identifier: str,
+        tracking_identifier: str,
+        event_type: WorkflowEventType,
+        message: str | None
+    ):
+        return cls(
+            identifier=uuid.uuid4(),
+            package_identifier=package_identifier,
+            tracking_identifier=tracking_identifier,
+            event_type=event_type,
+            timestamp=datetime.now(tz=UTC),
+            message=message
+        )

--- a/dor/service_layer/handlers/catalog_bin.py
+++ b/dor/service_layer/handlers/catalog_bin.py
@@ -28,5 +28,9 @@ def catalog_bin(event: PackageStored, uow: AbstractUnitOfWork) -> None:
         uow.catalog.add(bin)
         uow.commit()
 
-    uow.add_event(BinCataloged(identifier=event.identifier, tracking_identifier=event.tracking_identifier))
+    uow.add_event(BinCataloged(
+        identifier=event.identifier,
+        tracking_identifier=event.tracking_identifier,
+        package_identifier=event.package_identifier
+    ))
     

--- a/dor/service_layer/handlers/receive_package.py
+++ b/dor/service_layer/handlers/receive_package.py
@@ -8,8 +8,8 @@ def receive_package(event: PackageSubmitted, uow: AbstractUnitOfWork, translocat
 
     received_event = PackageReceived(
         package_identifier=event.package_identifier,
-        tracking_identifier='aintthatpeculiar',
+        tracking_identifier=event.tracking_identifier,
         workspace_identifier = workspace.identifier
     )
     
-    uow.add_event(received_event) 
+    uow.add_event(received_event)

--- a/dor/service_layer/handlers/record_workflow_event.py
+++ b/dor/service_layer/handlers/record_workflow_event.py
@@ -1,0 +1,14 @@
+from dor.domain.events import PackageEvent
+from dor.domain.models import WorkflowEvent, WorkflowEventType
+from dor.service_layer.unit_of_work import AbstractUnitOfWork
+
+
+def record_workflow_event(event: PackageEvent, uow: AbstractUnitOfWork):
+    with uow:
+        uow.event_store.add(WorkflowEvent.create(
+            tracking_identifier=event.tracking_identifier,
+            package_identifier=event.package_identifier,
+            event_type=WorkflowEventType(event.__class__.__name__),
+            message=getattr(event, "message") if hasattr(event, "message") else None
+        ))
+        uow.commit()

--- a/dor/service_layer/handlers/store_files.py
+++ b/dor/service_layer/handlers/store_files.py
@@ -38,6 +38,7 @@ def store_files(event: PackageUnpacked, uow: AbstractUnitOfWork, workspace_class
     stored_event = PackageStored(
         identifier=event.identifier,
         tracking_identifier=event.tracking_identifier,
+        package_identifier=event.package_identifier,
         resources=event.resources
     )
     uow.add_event(stored_event)

--- a/dor/service_layer/unit_of_work.py
+++ b/dor/service_layer/unit_of_work.py
@@ -3,7 +3,8 @@ from abc import ABC, abstractmethod
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from dor.adapters.catalog import Catalog, MemoryCatalog, SqlalchemyCatalog, _custom_json_serializer
+from dor.adapters.catalog import Catalog, MemoryCatalog, SqlalchemyCatalog
+from dor.adapters.sqlalchemy import _custom_json_serializer
 from dor.config import config
 from dor.domain.events import Event
 from gateway.repository_gateway import RepositoryGateway

--- a/features/steps/test_inspect_bin.py
+++ b/features/steps/test_inspect_bin.py
@@ -8,7 +8,7 @@ from pytest_bdd import scenario, given, when, then, parsers
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from dor.adapters.catalog import Base, _custom_json_serializer
+from dor.adapters.sqlalchemy import Base, _custom_json_serializer
 from dor.config import config
 from dor.domain.models import Bin
 from dor.providers.models import (

--- a/features/steps/test_store_resource.py
+++ b/features/steps/test_store_resource.py
@@ -10,7 +10,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from dor.adapters.bag_adapter import BagAdapter
-from dor.adapters.catalog import Base, _custom_json_serializer
+from dor.adapters.sqlalchemy import Base, _custom_json_serializer
 from dor.config import config
 from dor.domain.events import (
     Event,

--- a/features/steps/test_store_resource.py
+++ b/features/steps/test_store_resource.py
@@ -152,6 +152,6 @@ def _(unit_of_work: AbstractUnitOfWork, tracking_identifier: str):
         bin = unit_of_work.catalog.get(expected_identifier)
         assert bin is not None
 
-        workflow_events = unit_of_work.event_store.get_all_by_tracking_identifier(tracking_identifier)
+        workflow_events = unit_of_work.event_store.get_all_for_tracking_identifier(tracking_identifier)
         assert len(workflow_events) != 0
         assert workflow_events[0].event_type == WorkflowEventType.BIN_CATALOGED

--- a/features/steps/test_store_resource.py
+++ b/features/steps/test_store_resource.py
@@ -99,10 +99,12 @@ def message_bus(path_data: PathData, unit_of_work: AbstractUnitOfWork) -> Memory
         ],
         PackageUnpacked: [
             lambda event: record_workflow_event(event, unit_of_work),
-            lambda event: store_files(event, unit_of_work, Workspace)],
+            lambda event: store_files(event, unit_of_work, Workspace)
+        ],
         PackageStored: [
             lambda event: record_workflow_event(event, unit_of_work),
-            lambda event: catalog_bin(event, unit_of_work)],
+            lambda event: catalog_bin(event, unit_of_work)
+        ],
         BinCataloged: [
             lambda event: record_workflow_event(event, unit_of_work),
         ]
@@ -152,5 +154,4 @@ def _(unit_of_work: AbstractUnitOfWork, tracking_identifier: str):
 
         workflow_events = unit_of_work.event_store.get_all_by_tracking_identifier(tracking_identifier)
         assert len(workflow_events) != 0
-        workflow_events_by_time = sorted(workflow_events, key=lambda x: x.timestamp, reverse=True)
-        assert workflow_events_by_time[0].event_type == WorkflowEventType.BIN_CATALOGED
+        assert workflow_events[0].event_type == WorkflowEventType.BIN_CATALOGED

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 import sqlalchemy
 from fastapi.testclient import TestClient
 
-from dor.adapters.catalog import _custom_json_serializer, Base
+from dor.adapters.sqlalchemy import Base, _custom_json_serializer
 from dor.config import config
 from dor.domain.models import Bin
 from dor.entrypoints.api.dependencies import get_db_session

--- a/tests/test_event_store.py
+++ b/tests/test_event_store.py
@@ -46,7 +46,7 @@ def test_memory_event_store_gets_events_by_tracking_identifier(workflow_events: 
     for workflow_event in workflow_events:
         event_store.add(workflow_event)
 
-    events = event_store.get_all_by_tracking_identifier("some-tracking-id")
+    events = event_store.get_all_for_tracking_identifier("some-tracking-id")
     assert events == [workflow_events[1], workflow_events[0]]
 
 
@@ -76,5 +76,5 @@ def test_sqlalchemy_event_store_gets_events_by_tracking_identifier(db_session, w
             event_store.add(workflow_event)
         db_session.commit()
 
-    events = event_store.get_all_by_tracking_identifier(workflow_event.tracking_identifier)
+    events = event_store.get_all_for_tracking_identifier(workflow_event.tracking_identifier)
     assert events == [workflow_events[1], workflow_events[0]]

--- a/tests/test_event_store.py
+++ b/tests/test_event_store.py
@@ -1,0 +1,64 @@
+import uuid
+from datetime import datetime, UTC
+
+import pytest
+import sqlalchemy
+
+from dor.adapters.event_store import MemoryEventStore, SqlalchemyEventStore
+from dor.domain.models import WorkflowEvent, WorkflowEventType
+
+
+@pytest.fixture
+def workflow_event() -> WorkflowEvent:
+    return WorkflowEvent(
+        identifier=uuid.uuid4(),
+        package_identifier="xyzzy-0001-v1",
+        tracking_identifier="some-tracking-id",
+        event_type=WorkflowEventType.PACKAGE_STORED,
+        timestamp=datetime.now(tz=UTC),
+        message=None
+    )
+
+
+def test_memory_event_store_adds_event(workflow_event: WorkflowEvent):
+    event_store = MemoryEventStore()
+    event_store.add(workflow_event)
+
+    assert event_store.events == [workflow_event]
+
+
+def test_memory_event_store_gets_events_by_tracking_identifier(workflow_event):
+    event_store = MemoryEventStore()
+    event_store.add(workflow_event)
+
+    events = event_store.get_all_by_tracking_identifier("some-tracking-id")
+    assert events == [workflow_event]
+
+
+@pytest.mark.usefixtures("db_session")
+def test_sqlalchemy_event_store_adds_event(db_session, workflow_event: WorkflowEvent):
+    event_store = SqlalchemyEventStore(db_session)
+    with db_session.begin():
+        event_store.add(workflow_event)
+        db_session.commit()
+
+    rows = list(
+        db_session.execute(sqlalchemy.text("""
+            select *
+            from workflow_event
+            where identifier = :identifier
+        """), { "identifier": workflow_event.identifier })
+    )
+    assert len(rows) == 1
+    assert rows[0].identifier == workflow_event.identifier
+
+
+@pytest.mark.usefixtures("db_session")
+def test_sqlalchemy_event_store_gets_events_by_tracking_identifier(db_session, workflow_event: WorkflowEvent):
+    event_store = SqlalchemyEventStore(db_session)
+    with db_session.begin():
+        event_store.add(workflow_event)
+        db_session.commit()
+
+    events = event_store.get_all_by_tracking_identifier(workflow_event.tracking_identifier)
+    assert events == [workflow_event]

--- a/tests/test_unit_of_work.py
+++ b/tests/test_unit_of_work.py
@@ -3,7 +3,8 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from dor.adapters.catalog import SqlalchemyCatalog, Base, _custom_json_serializer
+from dor.adapters.catalog import SqlalchemyCatalog
+from dor.adapters.sqlalchemy import Base, _custom_json_serializer
 from dor.config import config
 from dor.service_layer.unit_of_work import SqlalchemyUnitOfWork
 


### PR DESCRIPTION
To Do
- [x] Create `WorkflowEvent` domain model
- [x] Create `MemoryEventStore`/`SqlalchemyEventStore` following repository pattern
- [x] Create separate file for `Base`, `_custom_json_serializer`
- [x] Create `record_wokflow_event` handler and register in message bus in response to events
