### PR TITLE
Update `DescriptorGenerator`, some other components after SIP evolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ requirements.txt
 output/
 .DS_Store
 tests/test_storage
-tests/test_workspaces
+tests/test_descriptor_generator
 
 features/scratch/*
 

--- a/dor/providers/descriptor_generator.py
+++ b/dor/providers/descriptor_generator.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 from datetime import datetime, UTC
 
-from dor.settings import template_env
 from dor.providers.models import PackageResource
+from dor.settings import template_env
 
 
 def build_descriptor_file_path(resource):
@@ -12,6 +12,7 @@ class DescriptorGenerator:
     def __init__(self, package_path: Path, resources: list[PackageResource]):
         self.package_path = package_path
         self.resources = resources
+
         self.entries = []
 
     def write_files(self):
@@ -28,9 +29,9 @@ class DescriptorGenerator:
                 struct_map_locref_data=struct_map_locref_data,
                 create_date=datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
             )
-            filename = build_descriptor_file_path(resource)
-            output_filename = self.package_path / filename
-            output_filename.parent.mkdir(parents=True, exist_ok=True)
-            with (output_filename).open("w") as f:
+            descriptor_file_path = build_descriptor_file_path(resource)
+            output_path = self.package_path / descriptor_file_path
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            with (output_path).open("w") as f:
                 f.write(xmldata)
-            self.entries.append(filename)
+            self.entries.append(descriptor_file_path)

--- a/dor/providers/descriptor_generator.py
+++ b/dor/providers/descriptor_generator.py
@@ -4,13 +4,9 @@ from datetime import datetime, UTC
 from dor.settings import template_env
 from dor.providers.models import PackageResource
 
-def relative_path_or_not(locref: str):
-    if locref.startswith("https://"):
-        return locref
-    return f"../{locref}"
 
-def build_descriptor_filename(resource):
-    return f"{resource.id}.{resource.type.lower().replace(" ", "_")}.mets2.xml"
+def build_descriptor_file_path(resource):
+    return Path(str(resource.id)) / "descriptor" / f"{resource.id}.{resource.type.lower().replace(" ", "_")}.mets2.xml"
 
 class DescriptorGenerator:
     def __init__(self, package_path: Path, resources: list[PackageResource]):
@@ -21,20 +17,18 @@ class DescriptorGenerator:
     def write_files(self):
         struct_map_locref_data = {}
         for resource in self.resources:
-            if resource.type == "Asset":
+            if resource.type == "File Set":
                 identifier = f"urn:dor:{resource.id}"
-                struct_map_locref_data[identifier] = build_descriptor_filename(resource)
+                struct_map_locref_data[identifier] = build_descriptor_file_path(resource)
 
         entity_template = template_env.get_template("preservation_mets.xml")
         for resource in self.resources:
             xmldata = entity_template.render(
-                relative_path_or_not=relative_path_or_not,
                 resource=resource,
                 struct_map_locref_data=struct_map_locref_data,
-                action="stored",
                 create_date=datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
             )
-            filename = Path(f"{resource.id}/descriptor/{build_descriptor_filename(resource)}")
+            filename = build_descriptor_file_path(resource)
             output_filename = self.package_path / filename
             output_filename.parent.mkdir(parents=True, exist_ok=True)
             with (output_filename).open("w") as f:

--- a/dor/providers/models.py
+++ b/dor/providers/models.py
@@ -72,6 +72,7 @@ class PackageResource:
     metadata_files: list[FileMetadata] = field(default_factory=list)
     data_files: list[FileMetadata] = field(default_factory=list)
     struct_maps: list[StructMap] = field(default_factory=list)
+    root: bool = False
 
     def get_entries(self) -> list[Path]:
         entries: list[Path] = []

--- a/dor/providers/models.py
+++ b/dor/providers/models.py
@@ -52,7 +52,7 @@ class StructMapType(Enum):
 class StructMapItem:
     order: int
     label: str
-    asset_id: str
+    file_set_id: str
     type: str | None = None
 
 

--- a/dor/providers/parsers.py
+++ b/dor/providers/parsers.py
@@ -130,13 +130,13 @@ class DescriptorFileParser:
             for order_elem in order_elems:
                 order_number = int(order_elem.get("ORDER"))
                 label = order_elem.get("LABEL")
-                asset_id = order_elem.get("ID")
+                file_set_id = order_elem.get("ID")
                 order_elem_type = order_elem.get_optional("TYPE")
                 struct_map_items.append(
                     StructMapItem(
                         order=order_number,
                         label=label,
-                        asset_id=asset_id,
+                        file_set_id=file_set_id,
                         type=order_elem_type,
                     )
                 )

--- a/dor/providers/parsers.py
+++ b/dor/providers/parsers.py
@@ -2,7 +2,6 @@ from datetime import datetime
 import uuid
 from pathlib import Path
 
-from dor.providers.file_provider import FileProvider
 from utils.element_adapter import ElementAdapter
 from .models import (
     Agent,
@@ -57,6 +56,11 @@ class DescriptorFileParser:
     def get_type(self):
         hdr = self.tree.find("METS:metsHdr")
         return hdr.get("TYPE")
+
+    def get_root(self):
+        header = self.tree.find("METS:metsHdr")
+        record_status = header.get_optional("RECORDSTATUS")
+        return record_status == "root"
 
     def get_alternate_identifier(self) -> AlternateIdentifier:
         alt_record_id = self.tree.find("METS:metsHdr/METS:altRecordID")

--- a/dor/providers/resource_provider.py
+++ b/dor/providers/resource_provider.py
@@ -36,6 +36,7 @@ class ResourceProvider:
             id=descriptor_file_parser.get_id(),
             alternate_identifier=descriptor_file_parser.get_alternate_identifier(),
             type=descriptor_file_parser.get_type(),
+            root=descriptor_file_parser.get_root(),
             events=pres_events,
             metadata_files=descriptor_file_parser.get_metadata_files(),
             data_files=descriptor_file_parser.get_data_files(),

--- a/features/steps/test_inspect_revision.py
+++ b/features/steps/test_inspect_revision.py
@@ -65,6 +65,7 @@ def _(alt_id, unit_of_work: AbstractUnitOfWork):
             PackageResource(
                 id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
                 type="Monograph",
+                root=True,
                 alternate_identifier=AlternateIdentifier(
                     id="xyzzy:00000001", type="DLXS"
                 ),

--- a/features/steps/test_inspect_revision.py
+++ b/features/steps/test_inspect_revision.py
@@ -110,13 +110,13 @@ def _(alt_id, unit_of_work: AbstractUnitOfWork):
                                 order=1,
                                 type="page",
                                 label="Page 1",
-                                asset_id="urn:dor:00000000-0000-0000-0000-000000001001",
+                                file_set_id="urn:dor:00000000-0000-0000-0000-000000001001",
                             ),
                             StructMapItem(
                                 order=2,
                                 type="page",
                                 label="Page 2",
-                                asset_id="urn:dor:00000000-0000-0000-0000-000000001002",
+                                file_set_id="urn:dor:00000000-0000-0000-0000-000000001002",
                             ),
                         ],
                     )

--- a/templates/partials/_md_file_sec.fragment.xml
+++ b/templates/partials/_md_file_sec.fragment.xml
@@ -2,7 +2,7 @@
   <METS:fileSec>
     {% for file in resource.data_files %}
     <METS:file ID="{{ file.id }}" {% if file.group_id %}GROUPID="{{ file.group_id }}"{% endif %} USE="{{ file.use }}"  MIMETYPE="{{ file.ref.mimetype }}" MDID="{{ file.mdid }}">
-      <METS:FLocat LOCTYPE="SYSTEM" LOCREF="{{ relative_path_or_not(file.ref.locref) }}" />
+      <METS:FLocat LOCTYPE="SYSTEM" LOCREF="{{ file.ref.locref }}" />
     </METS:file>
     {% endfor %}
   </METS:fileSec>

--- a/templates/partials/_md_sec.fragment.xml
+++ b/templates/partials/_md_sec.fragment.xml
@@ -2,7 +2,7 @@
   <METS:mdSec>
     {% for md in resource.metadata_files %}
     <METS:md ID="{{ md.id }}" USE="{{ md.use }}">
-      <METS:mdRef LOCREF="{{ relative_path_or_not(md.ref.locref) }}" LOCTYPE="URL" MDTYPE="{{ md.ref.mdtype }}" {% if md.ref.mimetype %}MIMETYPE="{{ md.ref.mimetype }}"{% endif %} />
+      <METS:mdRef LOCREF="{{ md.ref.locref }}" LOCTYPE="URL" MDTYPE="{{ md.ref.mdtype }}" {% if md.ref.mimetype %}MIMETYPE="{{ md.ref.mimetype }}"{% endif %} />
     </METS:md>
     {% endfor %}
   </METS:mdSec>

--- a/templates/partials/_struct_sec.fragment.xml
+++ b/templates/partials/_struct_sec.fragment.xml
@@ -4,8 +4,8 @@
     <METS:structMap ID="SM{{ loop.index }}" TYPE="{{ struct_map.type.value }}">
       <METS:div>
         {% for item in struct_map.items %}
-        <METS:div ORDERLABEL="{{ item.order }}" TYPE="{{ item.type }}" ORDER="{{ item.order }}" LABEL="{{ item.label }}" ID="{{ item.asset_id }}">
-          <METS:mptr LOCTYPE="URL" LOCREF="{{ struct_map_locref_data[item.asset_id] }}" />
+        <METS:div ORDERLABEL="{{ item.order }}" TYPE="{{ item.type }}" ORDER="{{ item.order }}" LABEL="{{ item.label }}" ID="{{ item.file_set_id }}">
+          <METS:mptr LOCTYPE="URL" LOCREF="{{ struct_map_locref_data[item.file_set_id] }}" />
         </METS:div>
         {% endfor %}
       </METS:div>

--- a/templates/partials/_struct_sec.fragment.xml
+++ b/templates/partials/_struct_sec.fragment.xml
@@ -1,7 +1,7 @@
 {% if resource.struct_maps|length > 0 %}
   <METS:structSec>
     {% for struct_map in resource.struct_maps %}
-    <METS:structMap ID="SM{{ loop.index }}" TYPE="{{ struct_map.type }}">
+    <METS:structMap ID="SM{{ loop.index }}" TYPE="{{ struct_map.type.value }}">
       <METS:div>
         {% for item in struct_map.items %}
         <METS:div ORDERLABEL="{{ item.order }}" TYPE="{{ item.type }}" ORDER="{{ item.order }}" LABEL="{{ item.label }}" ID="{{ item.asset_id }}">

--- a/templates/preservation_mets.xml
+++ b/templates/preservation_mets.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <METS:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:METS="http://www.loc.gov/METS/v2" xmlns:PREMIS="http://www.loc.gov/premis/v3" xmlns:dcam="http://purl.org/dc/dcam/" OBJID="{{ object_identifier }}" xsi:schemaLocation="http://www.loc.gov/METS/v2 ../v2/mets.xsd http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd">
 
-  <METS:metsHdr RECORDSTATUS="{{ action }}" CREATEDATE="{{ create_date }}" ID="HDR1" TYPE="{{ resource.type }}">
+  <METS:metsHdr {% if resource.root %}RECORDSTATUS="root"{% endif %} CREATEDATE="{{ create_date }}" ID="HDR1" TYPE="{{ resource.type }}">
     <METS:agent ROLE="CREATOR" TYPE="ORGANIZATION">
       <METS:name>University of Michigan - Library Information Technology - Digital Collection Services</METS:name>
     </METS:agent>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,13 +119,13 @@ def sample_revision() -> Revision:
                                 order=1,
                                 type="page",
                                 label="Page 1",
-                                asset_id="urn:dor:00000000-0000-0000-0000-000000001001",
+                                file_set_id="urn:dor:00000000-0000-0000-0000-000000001001",
                             ),
                             StructMapItem(
                                 order=2,
                                 type="page",
                                 label="Page 2",
-                                asset_id="urn:dor:00000000-0000-0000-0000-000000001002",
+                                file_set_id="urn:dor:00000000-0000-0000-0000-000000001002",
                             ),
                         ],
                     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,7 @@ def sample_revision() -> Revision:
             PackageResource(
                 id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
                 type="Monograph",
+                root=True,
                 alternate_identifier=AlternateIdentifier(id="xyzzy:00000001", type="DLXS"),
                 events=[
                     PreservationEvent(

--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -103,13 +103,13 @@ def test_catalog_has_empty_file_sets():
                                 order=1,
                                 type="page",
                                 label="Page 1",
-                                asset_id="urn:dor:00000000-0000-0000-0000-000000001001",
+                                file_set_id="urn:dor:00000000-0000-0000-0000-000000001001",
                             ),
                             StructMapItem(
                                 order=2,
                                 type="page",
                                 label="Page 2",
-                                asset_id="urn:dor:00000000-0000-0000-0000-000000001002",
+                                file_set_id="urn:dor:00000000-0000-0000-0000-000000001002",
                             ),
                         ],
                     )

--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -53,6 +53,7 @@ def test_catalog_has_empty_file_sets():
             PackageResource(
                 id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
                 type="Monograph",
+                root=True,
                 alternate_identifier=AlternateIdentifier(id="xyzzy:00000001", type="DLXS"),
                 events=[
                     PreservationEvent(

--- a/tests/test_descriptor_file_parser.py
+++ b/tests/test_descriptor_file_parser.py
@@ -121,13 +121,13 @@ class DescriptorFileParserTest(TestCase):
                         order=1,
                         type="page",
                         label="Page 1",
-                        asset_id="urn:dor:00000000-0000-0000-0000-000000001001",
+                        file_set_id="urn:dor:00000000-0000-0000-0000-000000001001",
                     ),
                     StructMapItem(
                         order=2,
                         type="page",
                         label="Page 2",
-                        asset_id="urn:dor:00000000-0000-0000-0000-000000001002",
+                        file_set_id="urn:dor:00000000-0000-0000-0000-000000001002",
                     ),
                 ],
             )

--- a/tests/test_descriptor_file_parser.py
+++ b/tests/test_descriptor_file_parser.py
@@ -47,6 +47,10 @@ class DescriptorFileParserTest(TestCase):
         parser = DescriptorFileParser(self.descriptor_path)
         self.assertEqual(parser.get_type(), "Monograph")
 
+    def test_parser_can_get_root(self):
+        parser = DescriptorFileParser(self.descriptor_path)
+        self.assertEqual(parser.get_root(), True)
+
     def test_parser_can_get_alternate_identifier(self):
         parser = DescriptorFileParser(self.descriptor_path)
 

--- a/tests/test_descriptor_generator.py
+++ b/tests/test_descriptor_generator.py
@@ -26,6 +26,7 @@ def sample_resources():
         PackageResource(
             id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
             type="Monograph",
+            root=True,
             alternate_identifier=AlternateIdentifier(id="xyzzy:00000001", type="DLXS"),
             events=[
                 PreservationEvent(
@@ -58,6 +59,24 @@ def sample_resources():
                         mimetype="application/json",
                     ),
                 ),
+                FileMetadata(
+                    id="_00000000-0000-0000-0000-000000000103",
+                    use="PROVENANCE",
+                    ref=FileReference(
+                        locref="00000000-0000-0000-0000-000000000001/metadata/00000000-0000-0000-0000-000000000001.premis.object.xml",
+                        mdtype="PREMIS",
+                        mimetype="text/xml",
+                    ),
+                ),
+                FileMetadata(
+                    id="_00000000-0000-0000-0000-000000000104",
+                    use="EVENT",
+                    ref=FileReference(
+                        locref="00000000-0000-0000-0000-000000000001/metadata/00000000-0000-0000-0000-000000000001.premis.event.xml",
+                        mdtype="PREMIS",
+                        mimetype="text/xml",
+                    ),
+                ),
             ],
             struct_maps=[
                 StructMap(
@@ -69,13 +88,7 @@ def sample_resources():
                             type="page",
                             label="Page 1",
                             asset_id="urn:dor:00000000-0000-0000-0000-000000001001",
-                        ),
-                        StructMapItem(
-                            order=2,
-                            type="page",
-                            label="Page 2",
-                            asset_id="urn:dor:00000000-0000-0000-0000-000000001002",
-                        ),
+                        )
                     ],
                 )
             ],
@@ -131,6 +144,14 @@ def sample_resources():
                     ref=FileReference(
                         locref="00000000-0000-0000-0000-000000001001/metadata/00000001.plaintext.txt.textmd.xml",
                         mdtype="TEXTMD",
+                    ),
+                ),
+                FileMetadata(
+                    id="_00000000-0000-0000-0000-000000100103",
+                    use="EVENT",
+                    ref=FileReference(
+                        locref="00000000-0000-0000-0000-000000001001/metadata/00000001.access.jpg.premis.event.xml",
+                        mdtype="PREMIS",
                     ),
                 ),
             ],

--- a/tests/test_descriptor_generator.py
+++ b/tests/test_descriptor_generator.py
@@ -1,10 +1,11 @@
-import os
-import shutil
-from pathlib import Path
 import uuid
-import pytest
 from datetime import datetime, UTC
+from pathlib import Path
 
+import pytest
+
+from dor.providers.descriptor_generator import DescriptorGenerator
+from dor.providers.file_system_file_provider import FilesystemFileProvider
 from dor.providers.models import (
     Agent,
     AlternateIdentifier,
@@ -17,8 +18,6 @@ from dor.providers.models import (
     StructMapType,
 )
 
-from dor.providers.translocator import Workspace
-from dor.providers.descriptor_generator import DescriptorGenerator
 
 @pytest.fixture
 def sample_resources():
@@ -190,9 +189,9 @@ def sample_resources():
     ]
 
 def test_generator_can_create_descriptor_files(sample_resources):
-    package_path = Path("./tests/test_workspaces")
-    shutil.rmtree(package_path, ignore_errors=True)
-    os.makedirs(package_path / "descriptor")
+    file_provider = FilesystemFileProvider()
+    package_path = Path("./tests/test_descriptor_generator")
+    file_provider.delete_dir_and_contents(package_path)
 
     generator = DescriptorGenerator(package_path=package_path, resources=sample_resources)
     generator.write_files()
@@ -201,9 +200,9 @@ def test_generator_can_create_descriptor_files(sample_resources):
     assert (package_path / "00000000-0000-0000-0000-000000001001" / "descriptor" / "00000000-0000-0000-0000-000000001001.file_set.mets2.xml" ).exists()
 
 def test_generator_can_return_entries(sample_resources):
-    package_path = Path("./tests/test_workspaces")
-    shutil.rmtree(package_path, ignore_errors=True)
-    os.makedirs(package_path / "descriptor")
+    file_provider = FilesystemFileProvider()
+    package_path = Path("./tests/test_descriptor_generator")
+    file_provider.delete_dir_and_contents(package_path)
 
     generator = DescriptorGenerator(package_path=package_path, resources=sample_resources)
     generator.write_files()

--- a/tests/test_descriptor_generator.py
+++ b/tests/test_descriptor_generator.py
@@ -87,7 +87,7 @@ def sample_resources():
                             order=1,
                             type="page",
                             label="Page 1",
-                            asset_id="urn:dor:00000000-0000-0000-0000-000000001001",
+                            file_set_id="urn:dor:00000000-0000-0000-0000-000000001001",
                         )
                     ],
                 )

--- a/tests/test_resource_provider.py
+++ b/tests/test_resource_provider.py
@@ -105,13 +105,13 @@ class ResourceProviderTest(TestCase):
                             order=1,
                             type="page",
                             label="Page 1",
-                            asset_id="urn:dor:00000000-0000-0000-0000-000000001001",
+                            file_set_id="urn:dor:00000000-0000-0000-0000-000000001001",
                         ),
                         StructMapItem(
                             order=2,
                             type="page",
                             label="Page 2",
-                            asset_id="urn:dor:00000000-0000-0000-0000-000000001002",
+                            file_set_id="urn:dor:00000000-0000-0000-0000-000000001002",
                         ),
                     ],
                 )

--- a/tests/test_resource_provider.py
+++ b/tests/test_resource_provider.py
@@ -44,6 +44,7 @@ class ResourceProviderTest(TestCase):
         expected_resource = PackageResource(
             id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
             type="Monograph",
+            root=True,
             alternate_identifier=AlternateIdentifier(id="xyzzy:00000001", type="DLXS"),
             events=[
                 PreservationEvent(


### PR DESCRIPTION
To Do
- [x] Fix paths in struct maps by changing `Asset` to `File Set` and removing `relative_or_not`
- [x] Tweak struct map type serialization so it uses the enum value
- [x] Introduce `PackageResource.root` for recording `RECORDSTATUS="root"`
- [x] Rename `StructMapItem.asset_id` -> `StructMapItem.file_set_id`
- [x] Rename output directory `tests/test_workspaces` -> `test_descriptor_generator` 
- [x] Use `FilsesystemFileProvider` for test directory cleanup and setup 