### PR TITLE
Replace "Asset" with "File Set"

### DIFF
--- a/dor/service_layer/catalog_service.py
+++ b/dor/service_layer/catalog_service.py
@@ -15,5 +15,5 @@ def summarize(revision: Revision):
 def get_file_sets(revision: Revision):
     return [
         to_jsonable_python(resource) 
-        for resource in revision.package_resources if resource.type == 'Asset'
+        for resource in revision.package_resources if resource.type == 'File Set'
     ]

--- a/features/steps/test_inspect_revision.py
+++ b/features/steps/test_inspect_revision.py
@@ -112,7 +112,7 @@ def _(alt_id, unit_of_work: AbstractUnitOfWork):
             ),
             PackageResource(
                 id=uuid.UUID("00000000-0000-0000-0000-000000001001"),
-                type="Asset",
+                type="File Set",
                 alternate_identifier=AlternateIdentifier(
                     id="xyzzy:00000001:00000001", type="DLXS"
                 ),
@@ -253,6 +253,6 @@ def _(alt_id, unit_of_work):
 def _(revision: Revision, file_sets):
     expected_file_sets = [
         to_jsonable_python(resource)
-        for resource in revision.package_resources if resource.type == 'Asset'
+        for resource in revision.package_resources if resource.type == 'File Set'
     ]
     assert file_sets == expected_file_sets

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,7 +138,7 @@ def sample_revision() -> Revision:
             ),
             PackageResource(
                 id=uuid.UUID("00000000-0000-0000-0000-000000001001"),
-                type="Asset",
+                type="File Set",
                 alternate_identifier=AlternateIdentifier(
                     id="xyzzy:00000001:00000001", type="DLXS"
                 ),

--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -28,7 +28,7 @@ def test_catalog_lists_file_sets(sample_revision):
     file_sets = get_file_sets(sample_revision)
     expected_file_sets = [
         to_jsonable_python(resource) 
-        for resource in sample_revision.package_resources if resource.type == 'Asset'
+        for resource in sample_revision.package_resources if resource.type == 'File Set'
     ]
 
     assert file_sets == expected_file_sets


### PR DESCRIPTION
This PR replaces some lingering usages of "Asset" with "File Set". I discovered this during some testing of the file set API endpoint when it returned an empty array. Tests were passing because the fixtures were still using "Asset".