### PR TITLE
Refactor tech metadata

### DIFF
--- a/dor/adapters/technical_metadata.py
+++ b/dor/adapters/technical_metadata.py
@@ -122,11 +122,8 @@ class JHOVEDoc:
     def mimetype(self) -> str:
         return self.retrieve_element_text(".//jhove:repInfo/jhove:mimeType")
     
-
     @property
     def technical_metadata(self) -> ET.Element:
         xpath = f'.//jhove:values[@type="{self.metadata_property}"]/jhove:value/*'
-        elem = self.retrieve_element(
-            xpath
-        )
+        elem = self.retrieve_element(xpath)
         return elem

--- a/dor/providers/process_basic_image.py
+++ b/dor/providers/process_basic_image.py
@@ -9,7 +9,7 @@ from typing import Callable
 from dor.adapters.generate_service_variant import generate_service_variant, ServiceImageProcessingError
 from dor.adapters.make_intermediate_file import make_intermediate_file
 from dor.adapters.technical_metadata import (
-    ImageMimetype, JHOVEDoc, JHOVEDocError
+    ImageMimetype, ImageTechnicalMetadata, JHOVEDocError
 )
 from dor.builders.parts import FileInfo, MetadataFileInfo, UseFunction, UseFormat, flatten_use
 from dor.providers.file_system_file_provider import FilesystemFileProvider
@@ -108,7 +108,7 @@ def process_basic_image(
     create_file_set_directories(file_set_directory)
 
     try:
-        source_tech_metadata = JHOVEDoc.create(image_path).technical_metadata
+        source_tech_metadata = ImageTechnicalMetadata.create(image_path)
     except JHOVEDocError:
         return False
 
@@ -134,7 +134,7 @@ def process_basic_image(
     source_tech_metadata_file_info = source_file_info.metadata(
         use=UseFunction.technical, mimetype=source_tech_metadata.metadata_mimetype.value
     )
-    (file_set_directory / source_tech_metadata_file_info.path).write_text(source_tech_metadata.metadata)
+    (file_set_directory / source_tech_metadata_file_info.path).write_text(str(source_tech_metadata))
 
     service_file_info = FileInfo(
         identifier=file_set_identifier.identifier,
@@ -165,14 +165,14 @@ def process_basic_image(
     (file_set_directory / service_event_metadata_file_info.path).write_text(service_event_xml)
 
     try:
-        service_tech_metadata = JHOVEDoc.create(service_file_path).technical_metadata
+        service_tech_metadata = ImageTechnicalMetadata.create(service_file_path)
     except JHOVEDocError:
         return False
 
     service_tech_metadata_file_info = service_file_info.metadata(
         use=UseFunction.technical, mimetype=service_tech_metadata.metadata_mimetype.value
     )
-    (file_set_directory / service_tech_metadata_file_info.path).write_text(service_tech_metadata.metadata)
+    (file_set_directory / service_tech_metadata_file_info.path).write_text(str(service_tech_metadata))
 
     resource = PackageResource(
         id=file_set_identifier.uuid,

--- a/tests/test_generate_service_variant.py
+++ b/tests/test_generate_service_variant.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from dor.adapters.generate_service_variant import generate_service_variant
-from dor.adapters.technical_metadata import ImageMimetype, JHOVEDoc
+from dor.adapters.technical_metadata import ImageMimetype, ImageTechnicalMetadata
 from dor.providers.file_system_file_provider import FilesystemFileProvider
 
 
@@ -25,7 +25,7 @@ def test_generate_service_variant_converts_to_jp2(fixtures_path, output_path):
     image_path = fixtures_path / "test_image.tiff"
     output_path = output_path / "test_image.jp2"
     generate_service_variant(image_path, output_path)
-    techmetadata = JHOVEDoc.create(output_path).technical_metadata
+    techmetadata = ImageTechnicalMetadata.create(output_path)
     
     assert techmetadata.mimetype == ImageMimetype.JP2
 

--- a/tests/test_make_intermediate_file.py
+++ b/tests/test_make_intermediate_file.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from dor.adapters.make_intermediate_file import make_intermediate_file
-from dor.adapters.technical_metadata import ImageMimetype, JHOVEDoc
+from dor.adapters.technical_metadata import ImageMimetype, ImageTechnicalMetadata
 
 
 @pytest.fixture
@@ -18,7 +18,7 @@ def test_make_intermediate_file_converts_jpg_to_uncompressed_tiff(fixtures_path)
     with temp_file:
         temp_file_path = Path(temp_file.name)
         make_intermediate_file(image_path, temp_file_path)
-        tech_metadata = JHOVEDoc.create(temp_file_path).technical_metadata
+        tech_metadata = ImageTechnicalMetadata.create(temp_file_path)
 
     assert tech_metadata.mimetype == ImageMimetype.TIFF
     assert not tech_metadata.compressed
@@ -30,7 +30,7 @@ def test_make_intermediate_file_unrotates_tiff(fixtures_path):
     with temp_file:
         temp_file_path = Path(temp_file.name)
         make_intermediate_file(image_path, temp_file_path)
-        tech_metadata = JHOVEDoc.create(temp_file_path).technical_metadata
+        tech_metadata = ImageTechnicalMetadata.create(temp_file_path)
 
     assert tech_metadata.mimetype == ImageMimetype.TIFF
     assert not tech_metadata.rotated
@@ -42,7 +42,7 @@ def test_make_intermediate_file_uncompresses_tiff(fixtures_path):
     with temp_file:
         temp_file_path = Path(temp_file.name)
         make_intermediate_file(image_path, temp_file_path)
-        tech_metadata = JHOVEDoc.create(temp_file_path).technical_metadata
+        tech_metadata = ImageTechnicalMetadata.create(temp_file_path)
 
     assert tech_metadata.mimetype == ImageMimetype.TIFF
     assert not tech_metadata.compressed

--- a/tests/test_technical_metadata.py
+++ b/tests/test_technical_metadata.py
@@ -26,7 +26,7 @@ def test_jhove_doc_retrieves_data_for_jpg(fixtures_path: Path):
     assert tech_metadata.metadata_mimetype == TechnicalMetadataMimetype.MIX
     assert not tech_metadata.rotated
     assert tech_metadata.compressed
-    assert tech_metadata.metadata
+    assert tech_metadata.metadata is not None
 
 
 def test_jhove_doc_retrieves_data_for_tiff(fixtures_path: Path):
@@ -36,7 +36,7 @@ def test_jhove_doc_retrieves_data_for_tiff(fixtures_path: Path):
     assert tech_metadata.metadata_mimetype == TechnicalMetadataMimetype.MIX
     assert not tech_metadata.rotated
     assert not tech_metadata.compressed
-    assert tech_metadata.metadata
+    assert tech_metadata.metadata is not None
 
 
 def test_jhove_doc_retrieves_data_for_rotated_tiff(fixtures_path: Path):
@@ -46,7 +46,7 @@ def test_jhove_doc_retrieves_data_for_rotated_tiff(fixtures_path: Path):
     assert tech_metadata.metadata_mimetype == TechnicalMetadataMimetype.MIX
     assert tech_metadata.rotated
     assert not tech_metadata.compressed
-    assert tech_metadata.metadata
+    assert tech_metadata.metadata is not None
 
 
 def test_jhove_doc_fails_when_status_is_invalid(jhove_elem: ET.Element):
@@ -107,17 +107,17 @@ def test_jhove_doc_fails_when_mimetype_has_no_text(jhove_elem: ET.Element):
         JHOVEDoc(jhove_elem, "Dummy").mimetype
 
 
-# def test_jhove_doc_fails_when_mix_is_missing(jhove_elem: ET.Element):
-#     niso_value_elem = jhove_elem.find(
-#         f".//jhove:values[@type='NISOImageMetadata']/jhove:value", NS_MAP
-#     )
-#     if niso_value_elem is None: raise Exception
-#     niso_mix_elem = niso_value_elem.find("./mix:mix", NS_MAP)
-#     if niso_mix_elem is None: raise Exception
-#     niso_value_elem.remove(niso_mix_elem)
+def test_jhove_doc_fails_when_mix_is_missing(jhove_elem: ET.Element):
+    niso_value_elem = jhove_elem.find(
+        f".//jhove:values[@type='NISOImageMetadata']/jhove:value", NS_MAP
+    )
+    if niso_value_elem is None: raise Exception
+    niso_mix_elem = niso_value_elem.find("./mix:mix", NS_MAP)
+    if niso_mix_elem is None: raise Exception
+    niso_value_elem.remove(niso_mix_elem)
 
-#     with pytest.raises(JHOVEDocError):
-#         JHOVEDoc(jhove_elem).niso_mix
+    with pytest.raises(JHOVEDocError):
+        JHOVEDoc(jhove_elem, "NISOImageMetadata").technical_metadata
 
 
 # def test_jhove_doc_fails_when_compression_is_missing(jhove_elem: ET.Element):

--- a/tests/test_technical_metadata.py
+++ b/tests/test_technical_metadata.py
@@ -19,7 +19,7 @@ def jhove_elem() -> ET.Element:
     return ET.fromstring(doc_path.read_text())
 
 
-def test_jhove_doc_retrieves_data_for_jpg(fixtures_path: Path):
+def test_image_tech_metadata_retrieves_data_for_jpg(fixtures_path: Path):
     image_path = fixtures_path / "test_image.jpg"
     tech_metadata = ImageTechnicalMetadata.create(image_path)
     assert tech_metadata.mimetype == ImageMimetype.JPEG
@@ -29,7 +29,7 @@ def test_jhove_doc_retrieves_data_for_jpg(fixtures_path: Path):
     assert tech_metadata.metadata is not None
 
 
-def test_jhove_doc_retrieves_data_for_tiff(fixtures_path: Path):
+def test_image_tech_metadata_retrieves_data_for_tiff(fixtures_path: Path):
     image_path = fixtures_path / "test_image.tiff"
     tech_metadata = ImageTechnicalMetadata.create(image_path)
     assert tech_metadata.mimetype == ImageMimetype.TIFF
@@ -39,7 +39,7 @@ def test_jhove_doc_retrieves_data_for_tiff(fixtures_path: Path):
     assert tech_metadata.metadata is not None
 
 
-def test_jhove_doc_retrieves_data_for_rotated_tiff(fixtures_path: Path):
+def test_image_tech_metadata_retrieves_data_for_rotated_tiff(fixtures_path: Path):
     image_path = fixtures_path / "test_image_rotated.tiff"
     tech_metadata = ImageTechnicalMetadata.create(image_path)
     assert tech_metadata.mimetype == ImageMimetype.TIFF
@@ -118,23 +118,3 @@ def test_jhove_doc_fails_when_mix_is_missing(jhove_elem: ET.Element):
 
     with pytest.raises(JHOVEDocError):
         JHOVEDoc(jhove_elem, "NISOImageMetadata").technical_metadata
-
-
-# def test_jhove_doc_fails_when_compression_is_missing(jhove_elem: ET.Element):
-#     compression_elem = jhove_elem.find(".//mix:Compression", NS_MAP)
-#     if compression_elem is None: raise Exception
-#     compression_scheme_elem = compression_elem.find("./mix:compressionScheme", NS_MAP)
-#     if compression_scheme_elem is None: raise Exception
-#     compression_elem.remove(compression_scheme_elem)
-
-#     with pytest.raises(JHOVEDocError):
-#         JHOVEDoc(jhove_elem).compressed
-
-
-# def test_jhove_doc_fails_when_compression_has_no_text(jhove_elem: ET.Element):
-#     compression_scheme_elem = jhove_elem.find(".//mix:Compression/mix:compressionScheme", NS_MAP)
-#     if compression_scheme_elem is None: raise Exception
-#     compression_scheme_elem.text = None
-
-#     with pytest.raises(JHOVEDocError):
-#         JHOVEDoc(jhove_elem).compressed


### PR DESCRIPTION
Making `JHOVEDoc` dumber and enhancing `ImageTechnicalMetadata`. The idea is that the text technical metadata (or other formats) would have their own properties.

Less clear about testing for presence of values in the `mix` metadata (e.g. compression) unless they're required by the underlying schema, so those are commented out.