### PR TITLE
Resolves DOR-63 CopySource Operation UseFormat

### DIFF
--- a/dor/builders/parts.py
+++ b/dor/builders/parts.py
@@ -112,14 +112,15 @@ class UseFormat(str, _Enum):
                 return cls.audiovisual
             case "text":
                 # For text types, we need to check specific subtypes
-                if subtype == "plain":
-                    return cls.text_plain
-                elif "annotation" in subtype:
-                    return cls.text_annotations
-                elif "coordinate" in subtype:
-                    return cls.text_coordinates
-                else:
-                    return cls.text_encoded
+                match subtype:
+                    case "plain":
+                        return cls.text_plain
+                    case _ if "annotation" in subtype:
+                        return cls.text_annotations
+                    case _ if "coordinate" in subtype:
+                        return cls.text_coordinates
+                    case _:
+                        return cls.text_encoded
             case _:
                 raise ValueError(f"Unable to determine UseFormat for MIME type: {mimetype}")
 

--- a/dor/builders/parts.py
+++ b/dor/builders/parts.py
@@ -55,6 +55,7 @@ class _Enum(Enum):
     def __str__(self):
         return self.value
 
+
 class UseFunction(str, _Enum):
     service = "function:service"
     source = "function:source"
@@ -66,13 +67,54 @@ class UseFunction(str, _Enum):
 
 
 class UseFormat(str, _Enum):
-    image = "format:image"
-    audiovidual = "format:audiovisual"
     audio = "format:audio"
-    text_coordinates = "format:text-coordinate"
-    text_plain = "format:text-plain"
+    audiovisual = "format:audiovisual"
+    image = "format:image"
     text_annotations = "format:text-annotation"
+    text_coordinates = "format:text-coordinate"
     text_encoded = "format:text-encoded"
+    text_plain = "format:text-plain"
+
+    @classmethod
+    def from_mimetype(cls, mimetype: str) -> "UseFormat":
+        """
+        Creates a UseFormat instance based on the given MIME type.
+
+        Args:
+            mimetype: A string representing the MIME type (e.g., 'image/jpeg', 'audio/mp3')
+
+        Returns:
+            UseFormat: The corresponding UseFormat enum value
+
+        Raises:
+            ValueError: If the MIME type cannot be mapped to a UseFormat
+        """
+        # Strip any parameters from the mimetype (e.g., 'text/plain; charset=UTF-8' -> 'text/plain')
+        base_mimetype = mimetype.split(';')[0].strip()
+
+        # Check the main type (before the '/')
+        main_type = base_mimetype.split('/')[0]
+
+        match main_type:
+            case "image":
+                return cls.image
+            case "audio":
+                return cls.audio
+            case "video":
+                return cls.audiovisual
+            case "text":
+                # For text types, we need to check specific subtypes
+                subtype = base_mimetype.split('/')[1]
+                if subtype == "plain":
+                    return cls.text_plain
+                elif "annotation" in subtype:
+                    return cls.text_annotations
+                elif "coordinate" in subtype:
+                    return cls.text_coordinates
+                else:
+                    return cls.text_encoded
+            case _:
+                raise ValueError(f"Unable to determine UseFormat for MIME type: {mimetype}")
 
 
 class StructureType(str, _Enum):
@@ -166,7 +208,7 @@ class FileInfo:
     @property
     def place(self):
         return "data"
-    
+
     @property
     def xmlid(self):
         return f"_{self.id}"

--- a/dor/builders/parts.py
+++ b/dor/builders/parts.py
@@ -92,6 +92,14 @@ class UseFormat(str, _Enum):
         # Strip any parameters from the mimetype (e.g., 'text/plain; charset=UTF-8' -> 'text/plain')
         base_mimetype = mimetype.split(';')[0].strip()
 
+        try:
+            subtype = base_mimetype.split('/')[1]
+        except IndexError:
+            raise ValueError(f"Unable to determine UseFormat for MIME type: {mimetype}")
+
+        if not subtype:
+            raise ValueError(f"Unable to determine UseFormat for MIME type: {mimetype}")
+
         # Check the main type (before the '/')
         main_type = base_mimetype.split('/')[0]
 
@@ -104,7 +112,6 @@ class UseFormat(str, _Enum):
                 return cls.audiovisual
             case "text":
                 # For text types, we need to check specific subtypes
-                subtype = base_mimetype.split('/')[1]
                 if subtype == "plain":
                     return cls.text_plain
                 elif "annotation" in subtype:

--- a/dor/builders/parts.py
+++ b/dor/builders/parts.py
@@ -109,7 +109,7 @@ class UseFormat(str, _Enum):
             case "application":
                 # For application types, we need to check specific subtypes
                 match subtype:
-                    case _ if "annotation+json" in subtype:
+                    case "annotation+json":
                         return cls.text_annotations
                     case _:
                         raise ValueError(f"Unable to determine UseFormat for MIME type: {mimetype}")

--- a/dor/providers/process_basic_image.py
+++ b/dor/providers/process_basic_image.py
@@ -148,7 +148,7 @@ class Accumulator:
             metadata_file_infos.append(tech_metadata_file_info)
             file_info_associations.append(result.association)
 
-        # write descriptor file
+        # write the descriptor file
         resource = create_package_resource(
             file_set_identifier=self.file_set_identifier,
             metadata_file_infos=metadata_file_infos,
@@ -160,7 +160,7 @@ class Accumulator:
             / "descriptor"
             / f"{self.file_set_identifier.identifier}.file_set.mets2.xml"
         )
-        with (descriptor_file_path).open("w") as file:
+        with descriptor_file_path.open("w") as file:
             file.write(descriptor_xml)
 
 
@@ -211,6 +211,7 @@ def create_file_set_directories(file_set_directory: Path) -> None:
 
 def get_event_file_info(file_info: FileInfo):
     return file_info.metadata(use=UseFunction.event, mimetype="text/xml+premis")
+
 
 def create_package_resource(
     file_set_identifier: FileSetIdentifier,
@@ -275,7 +276,7 @@ class Input:
 
 @dataclass
 class CopySource(Operation):
-    image_path: Path
+    file_path: Path
 
     @staticmethod
     def copy_source_file(source_path: Path, destination_path: Path) -> None:
@@ -283,7 +284,7 @@ class CopySource(Operation):
 
     def run(self) -> None:
         try:
-            source_tech_metadata = TechnicalMetadata.create(self.image_path)
+            source_tech_metadata = TechnicalMetadata.create(self.file_path)
         except JHOVEDocError:
             return None
 
@@ -295,7 +296,7 @@ class CopySource(Operation):
         )
 
         source_file_path = self.accumulator.file_set_directory / file_info.path
-        self.copy_source_file(source_path=self.image_path, destination_path=source_file_path)
+        self.copy_source_file(source_path=self.file_path, destination_path=source_file_path)
 
         event = create_preservation_event(
             "copy source file", self.accumulator.collection_manager_email
@@ -414,7 +415,7 @@ def process_basic_image(
     )
 
     for input in inputs:
-        CopySource(accumulator=accumulator, image_path=input.file_path).run()
+        CopySource(accumulator=accumulator, file_path=input.file_path).run()
         OrientSourceImage(accumulator).run()
         for command in input.commands:
             command.operation(accumulator=accumulator, **command.kwargs).run()

--- a/dor/providers/process_basic_image.py
+++ b/dor/providers/process_basic_image.py
@@ -165,11 +165,11 @@ class Accumulator:
 
 
 def create_preservation_event(
-    type: str, collection_manager_email: str, detail: str = ""
+    event_type: str, collection_manager_email: str, detail: str = ""
 ):
     event = PreservationEvent(
         identifier=str(uuid.uuid4()),
-        type=type,
+        type=event_type,
         datetime=datetime.now(tz=UTC),
         detail=detail,
         agent=Agent(role="image_processing", address=collection_manager_email),
@@ -291,7 +291,7 @@ class CopySource(Operation):
         file_info = FileInfo(
             identifier=self.accumulator.file_set_identifier.identifier,
             basename=self.accumulator.file_set_identifier.basename,
-            uses=[UseFunction.source, UseFormat.image],
+            uses=[UseFunction.source, UseFormat.from_mimetype(source_tech_metadata.mimetype.value)],
             mimetype=source_tech_metadata.mimetype.value,
         )
 
@@ -310,6 +310,7 @@ class CopySource(Operation):
                 event=event
             )
         )
+        return None
 
 
 @dataclass
@@ -356,6 +357,7 @@ class OrientSourceImage(Operation):
                 event=event
             )
         )
+        return None
 
 
 @dataclass
@@ -397,6 +399,7 @@ class CompressSourceImage(Operation):
                 event=event,
             )
         )
+        return None
 
 
 def process_basic_image(

--- a/tests/test_use_format_from_mimetype_factory.py
+++ b/tests/test_use_format_from_mimetype_factory.py
@@ -37,7 +37,7 @@ def test_from_mimetype_text():
 def test_from_mimetype_with_parameters():
     # Test MIME types with parameters
     assert UseFormat.from_mimetype("text/plain; charset=UTF-8") == UseFormat.text_plain
-    assert UseFormat.from_mimetype("text/plain;charset=US-ASCII") == UseFormat.text_plain
+    assert UseFormat.from_mimetype("text/plain; charset=US-ASCII") == UseFormat.text_plain
 
 
 def test_from_mimetype_invalid():

--- a/tests/test_use_format_from_mimetype_factory.py
+++ b/tests/test_use_format_from_mimetype_factory.py
@@ -3,7 +3,7 @@ from dor.builders.parts import UseFormat
 
 
 def test_from_mimetype_application():
-    # Test audio MIME types
+    # Test application MIME types
     assert UseFormat.from_mimetype("application/annotation+json") == UseFormat.text_annotations
 
     with pytest.raises(ValueError):
@@ -21,7 +21,7 @@ def test_from_mimetype_audio():
 
 
 def test_from_mimetype_image():
-    # Test various image MIME types
+    # Test image MIME types
     assert UseFormat.from_mimetype("image/jpeg") == UseFormat.image
     assert UseFormat.from_mimetype("image/png") == UseFormat.image
     assert UseFormat.from_mimetype("image/tiff") == UseFormat.image
@@ -29,7 +29,7 @@ def test_from_mimetype_image():
 
 
 def test_from_mimetype_text():
-    # Test various text MIME types
+    # Test text MIME types
     assert UseFormat.from_mimetype("text/plain") == UseFormat.text_plain
     assert UseFormat.from_mimetype("text/plain; charset=UTF-8") == UseFormat.text_plain
     assert UseFormat.from_mimetype("text/annotation+xml") == UseFormat.text_annotations

--- a/tests/test_use_format_from_mimetype_factory.py
+++ b/tests/test_use_format_from_mimetype_factory.py
@@ -1,0 +1,64 @@
+import pytest
+from dor.builders.parts import UseFormat
+
+
+def test_from_mimetype_image():
+    # Test various image MIME types
+    assert UseFormat.from_mimetype("image/jpeg") == UseFormat.image
+    assert UseFormat.from_mimetype("image/png") == UseFormat.image
+    assert UseFormat.from_mimetype("image/tiff") == UseFormat.image
+    assert UseFormat.from_mimetype("image/gif") == UseFormat.image
+
+
+def test_from_mimetype_audio():
+    # Test audio MIME types
+    assert UseFormat.from_mimetype("audio/mp3") == UseFormat.audio
+    assert UseFormat.from_mimetype("audio/wav") == UseFormat.audio
+    assert UseFormat.from_mimetype("audio/ogg") == UseFormat.audio
+
+
+def test_from_mimetype_video():
+    # Test video MIME types (should return audiovisual)
+    assert UseFormat.from_mimetype("video/mp4") == UseFormat.audiovisual
+    assert UseFormat.from_mimetype("video/mpeg") == UseFormat.audiovisual
+    assert UseFormat.from_mimetype("video/quicktime") == UseFormat.audiovisual
+
+
+def test_from_mimetype_text():
+    # Test various text MIME types
+    assert UseFormat.from_mimetype("text/plain") == UseFormat.text_plain
+    assert UseFormat.from_mimetype("text/plain; charset=UTF-8") == UseFormat.text_plain
+    assert UseFormat.from_mimetype("text/annotation+xml") == UseFormat.text_annotations
+    assert UseFormat.from_mimetype("text/coordinate") == UseFormat.text_coordinates
+    assert UseFormat.from_mimetype("text/html") == UseFormat.text_encoded
+    assert UseFormat.from_mimetype("text/xml") == UseFormat.text_encoded
+
+
+def test_from_mimetype_with_parameters():
+    # Test MIME types with parameters
+    assert UseFormat.from_mimetype("text/plain; charset=UTF-8") == UseFormat.text_plain
+    assert UseFormat.from_mimetype("text/plain;charset=US-ASCII") == UseFormat.text_plain
+
+
+def test_from_mimetype_invalid():
+    # Test invalid MIME types
+    with pytest.raises(ValueError):
+        UseFormat.from_mimetype("invalid/type")
+
+    with pytest.raises(ValueError):
+        UseFormat.from_mimetype("application/json")
+
+    with pytest.raises(ValueError):
+        UseFormat.from_mimetype("")
+
+
+def test_from_mimetype_malformed():
+    # Test malformed MIME types
+    with pytest.raises(ValueError):
+        UseFormat.from_mimetype("image")
+
+    with pytest.raises(ValueError):
+        UseFormat.from_mimetype("/jpeg")
+
+    with pytest.raises(ValueError):
+        UseFormat.from_mimetype("image/")

--- a/tests/test_use_format_from_mimetype_factory.py
+++ b/tests/test_use_format_from_mimetype_factory.py
@@ -2,12 +2,15 @@ import pytest
 from dor.builders.parts import UseFormat
 
 
-def test_from_mimetype_image():
-    # Test various image MIME types
-    assert UseFormat.from_mimetype("image/jpeg") == UseFormat.image
-    assert UseFormat.from_mimetype("image/png") == UseFormat.image
-    assert UseFormat.from_mimetype("image/tiff") == UseFormat.image
-    assert UseFormat.from_mimetype("image/gif") == UseFormat.image
+def test_from_mimetype_application():
+    # Test audio MIME types
+    assert UseFormat.from_mimetype("application/annotation+json") == UseFormat.text_annotations
+
+    with pytest.raises(ValueError):
+        UseFormat.from_mimetype("application/json")
+
+    with pytest.raises(ValueError):
+        UseFormat.from_mimetype("application/xml")
 
 
 def test_from_mimetype_audio():
@@ -17,11 +20,12 @@ def test_from_mimetype_audio():
     assert UseFormat.from_mimetype("audio/ogg") == UseFormat.audio
 
 
-def test_from_mimetype_video():
-    # Test video MIME types (should return audiovisual)
-    assert UseFormat.from_mimetype("video/mp4") == UseFormat.audiovisual
-    assert UseFormat.from_mimetype("video/mpeg") == UseFormat.audiovisual
-    assert UseFormat.from_mimetype("video/quicktime") == UseFormat.audiovisual
+def test_from_mimetype_image():
+    # Test various image MIME types
+    assert UseFormat.from_mimetype("image/jpeg") == UseFormat.image
+    assert UseFormat.from_mimetype("image/png") == UseFormat.image
+    assert UseFormat.from_mimetype("image/tiff") == UseFormat.image
+    assert UseFormat.from_mimetype("image/gif") == UseFormat.image
 
 
 def test_from_mimetype_text():
@@ -32,6 +36,13 @@ def test_from_mimetype_text():
     assert UseFormat.from_mimetype("text/coordinate") == UseFormat.text_coordinates
     assert UseFormat.from_mimetype("text/html") == UseFormat.text_encoded
     assert UseFormat.from_mimetype("text/xml") == UseFormat.text_encoded
+
+
+def test_from_mimetype_video():
+    # Test video MIME types (should return audiovisual)
+    assert UseFormat.from_mimetype("video/mp4") == UseFormat.audiovisual
+    assert UseFormat.from_mimetype("video/mpeg") == UseFormat.audiovisual
+    assert UseFormat.from_mimetype("video/quicktime") == UseFormat.audiovisual
 
 
 def test_from_mimetype_with_parameters():


### PR DESCRIPTION
    @classmethod
    def from_mimetype(cls, mimetype: str) -> "UseFormat":
        """
        Creates a UseFormat instance based on the given MIME type.
        Args:
            mimetype: A string representing the MIME type (e.g., 'image/jpeg', 'audio/mp3')
        Returns:
            UseFormat: The corresponding UseFormat enum value
        Raises:
            ValueError: If the MIME type cannot be mapped to a UseFormat
        """