### PR TITLE
Combine some OCR tests

### DIFF
--- a/tests/test_file_set_processor_with_ocr.py
+++ b/tests/test_file_set_processor_with_ocr.py
@@ -56,112 +56,81 @@ def image_with_plain_text_only_input(input_path: Path) -> Input:
     return Input(file_path=input_path / "quick-brown.tiff", commands=commands)
 
 
-def test_process_creates_text_coordinates_file(file_set_identifier, image_with_ocr_input, output_path):
+def test_process_creates_text_coordinates_file_and_metadata(
+    file_set_identifier, image_with_ocr_input, output_path
+):
+    assert process_basic_image(
+        file_set_identifier=file_set_identifier,
+        inputs=[image_with_ocr_input],
+        output_path=output_path
+    )
+
     text_coordinates_file = output_path / file_set_identifier.identifier /  \
         "data" / ("quick-brown.function:service.format:text-coordinate.xml")
-
-    assert process_basic_image(
-        file_set_identifier=file_set_identifier,
-        inputs=[image_with_ocr_input],
-        output_path=output_path
-    )
     assert text_coordinates_file.exists()
 
-
-def test_process_creates_technical_metadata_for_text_coordinates(file_set_identifier, image_with_ocr_input, output_path):
     technical_metadata_file = output_path / file_set_identifier.identifier / "metadata" / \
         ("quick-brown.function:service.format:text-coordinate.xml.function:technical.textmd.xml")
-    assert process_basic_image(
-        file_set_identifier=file_set_identifier,
-        inputs=[image_with_ocr_input],
-        output_path=output_path
-    )
     assert technical_metadata_file.exists()
 
-
-def test_process_creates_event_for_text_coordinates(file_set_identifier, image_with_ocr_input, output_path):
     event_metadata_file = output_path / file_set_identifier.identifier / "metadata" / \
         ("quick-brown.function:service.format:text-coordinate.xml.function:event.premis.xml")
-    assert process_basic_image(
-        file_set_identifier=file_set_identifier,
-        inputs=[image_with_ocr_input],
-        output_path=output_path
-    )
     assert event_metadata_file.exists()
 
 
-def test_process_creates_plain_text_file(file_set_identifier, image_with_ocr_input, output_path):
-    plain_text_file = output_path / file_set_identifier.identifier /  \
-        "data" / ("quick-brown.function:service.format:text-plain.txt")
+def test_process_creates_plain_text_file_and_metadata(
+    file_set_identifier, image_with_ocr_input, output_path
+):
     assert process_basic_image(
         file_set_identifier=file_set_identifier,
         inputs=[image_with_ocr_input],
         output_path=output_path
     )
+
+    plain_text_file = output_path / file_set_identifier.identifier /  \
+        "data" / ("quick-brown.function:service.format:text-plain.txt")
     assert plain_text_file.exists()
 
-
-def test_process_creates_technical_metadata_for_plain_text(file_set_identifier, image_with_ocr_input, output_path):
     technical_metadata_file = output_path / file_set_identifier.identifier / "metadata" / \
         ("quick-brown.function:service.format:text-plain.txt.function:technical.textmd.xml")
-    assert process_basic_image(
-        file_set_identifier=file_set_identifier,
-        inputs=[image_with_ocr_input],
-        output_path=output_path
-    )
     assert technical_metadata_file.exists()
 
-
-def test_process_creates_event_for_plain_text(file_set_identifier, image_with_ocr_input, output_path):
     event_metadata_file = output_path / file_set_identifier.identifier / "metadata" / \
         ("quick-brown.function:service.format:text-plain.txt.function:event.premis.xml")
+    assert event_metadata_file.exists()
+
+
+def test_process_creates_annotation_data_file_and_metadata(
+    file_set_identifier, image_with_ocr_input, output_path
+):
     assert process_basic_image(
         file_set_identifier=file_set_identifier,
         inputs=[image_with_ocr_input],
         output_path=output_path
     )
-    assert event_metadata_file.exists()
 
-
-def test_process_creates_annotation_data_file(file_set_identifier, image_with_ocr_input, output_path):
     annotation_file = output_path / file_set_identifier.identifier /  \
         "data" / ("quick-brown.function:service.format:text-annotation.json")
-    assert process_basic_image(
-        file_set_identifier=file_set_identifier,
-        inputs=[image_with_ocr_input],
-        output_path=output_path
-    )
     assert annotation_file.exists()
 
-
-def test_process_creates_technical_metadata_for_annotation_data_file(file_set_identifier, image_with_ocr_input, output_path):
     technical_metadata_file = output_path / file_set_identifier.identifier / "metadata" / \
         ("quick-brown.function:service.format:text-annotation.json.function:technical.textmd.xml")
-    assert process_basic_image(
-        file_set_identifier=file_set_identifier,
-        inputs=[image_with_ocr_input],
-        output_path=output_path
-    )
     assert technical_metadata_file.exists()
 
-
-def test_process_creates_event_for_annotation_data_file(file_set_identifier, image_with_ocr_input, output_path):
     event_metadata_file = output_path / file_set_identifier.identifier / "metadata" / \
         ("quick-brown.function:service.format:text-annotation.json.function:event.premis.xml")
-    assert process_basic_image(
-        file_set_identifier=file_set_identifier,
-        inputs=[image_with_ocr_input],
-        output_path=output_path
-    )
     assert event_metadata_file.exists()
 
 
-def test_process_creates_plain_text_without_text_coordinates(file_set_identifier, image_with_plain_text_only_input, output_path):
-    plain_text_file = output_path / file_set_identifier.identifier /  \
-        "data" / ("quick-brown.function:service.format:text-plain.txt")
+def test_process_creates_plain_text_without_text_coordinates(
+    file_set_identifier, image_with_plain_text_only_input, output_path
+):
     assert process_basic_image(
         file_set_identifier=file_set_identifier,
         inputs=[image_with_plain_text_only_input],
         output_path=output_path
     )
+
+    plain_text_file = output_path / file_set_identifier.identifier /  \
+        "data" / ("quick-brown.function:service.format:text-plain.txt")
     assert plain_text_file.exists()


### PR DESCRIPTION
This PR modifies some file set processor tests using OCR in order to speed up test execution. Tests that were related to a single operation were combined by using multiple assertions per test. In other words, tests check for the existence of a data file as well as the related technical metadata and event files. This reduces the number of times Tesseract is run during the test suite.