### PR TITLE
DOR-69 -  find bins by referenced file set identifiers

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -26,7 +26,7 @@ pytest_plugins = [
 @pytest.fixture
 def db_session() -> Generator[sqlalchemy.orm.Session, None, None]:
     engine_url = config.get_database_engine_url()
-    engine = sqlalchemy.create_engine(engine_url, echo=True)
+    engine = sqlalchemy.create_engine(engine_url, echo=False)
 
     Base.metadata.drop_all(engine)
     Base.metadata.create_all(engine)
@@ -73,9 +73,9 @@ def sample_revision() -> Revision:
                 id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
                 type="Monograph",
                 root=True,
-                alternate_identifier=AlternateIdentifier(
+                alternate_identifier=[AlternateIdentifier(
                     id="xyzzy:00000001", type="DLXS"
-                ),
+                )],
                 events=[
                     PreservationEvent(
                         identifier="abdcb901-721a-4be0-a981-14f514236633",
@@ -132,9 +132,9 @@ def sample_revision() -> Revision:
             PackageResource(
                 id=uuid.UUID("00000000-0000-0000-0000-000000001001"),
                 type="File Set",
-                alternate_identifier=AlternateIdentifier(
+                alternate_identifier=[AlternateIdentifier(
                     id="xyzzy:00000001:00000001", type="DLXS"
-                ),
+                )],
                 events=[
                     PreservationEvent(
                         identifier="fe4c76e5-dbf1-4934-97fb-52ef5a68f073",
@@ -224,3 +224,169 @@ def sample_revision_two(sample_revision) -> Revision:
     sample_revision_two.created_at = datetime(2025, 2, 11, 12, 0, 0, 0, tzinfo=UTC)
     sample_revision_two.common_metadata["subjects"].append("Something new")
     return sample_revision_two
+
+@pytest.fixture
+def referenced_revision() -> Revision:
+    return Revision(
+        identifier=uuid.UUID("00000000-0000-0000-0000-000000000002"),
+        alternate_identifiers=["xyzzy:00000002"],
+        revision_number=1,
+        created_at=datetime(2025, 2, 5, 12, 0, 0, 0, tzinfo=UTC),
+        common_metadata={
+            "@schema": "urn:umich.edu:dor:schema:common",
+            "title": "Discussion also Republican owner hot already itself.",
+            "author": "Kimberly Garza",
+            "publication_date": "1989-04-16",
+            "subjects": [
+                "Liechtenstein",
+                "Vietnam",
+            ],
+        },
+        package_resources=[
+            PackageResource(
+                id=uuid.UUID("00000000-0000-0000-0000-000000000002"),
+                type="Monograph",
+                root=True,
+                alternate_identifier=[AlternateIdentifier(
+                    id="xyzzy:00000002", type="DLXS"
+                )],
+                events=[
+                    PreservationEvent(
+                        identifier="abdcb901-721a-4be0-a981-14f514236633",
+                        type="ingest",
+                        datetime=datetime(2016, 11, 29, 13, 51, 14, tzinfo=UTC),
+                        detail="Middle president push visit information feel most.",
+                        agent=Agent(
+                            address="christopherpayne@example.org",
+                            role="collection manager",
+                        ),
+                    )
+                ],
+                metadata_files=[
+                    FileMetadata(
+                        id="_0193d5f0-7f64-7ac8-8f94-85c55c7313e4",
+                        use="function:service",
+                        ref=FileReference(
+                            locref="../metadata/00000000-0000-0000-0000-000000000001.function:service.json",
+                            mdtype="schema:common",
+                            mimetype="application/json+schema",
+                        ),
+                    ),
+                    FileMetadata(
+                        id="_0193d5f0-7f65-783e-b7b4-485b6f6b24d0",
+                        use="function:source",
+                        ref=FileReference(
+                            locref="../metadata/00000000-0000-0000-0000-000000000001.function:source.json",
+                            mdtype="schema:monograph",
+                            mimetype="application/json+schema",
+                        ),
+                    ),
+                ],
+                struct_maps=[
+                    StructMap(
+                        id="SM1",
+                        type=StructMapType.physical,
+                        items=[
+                            StructMapItem(
+                                order=1,
+                                type="structure:page",
+                                label="Page 1",
+                                file_set_id="00000000-0000-0000-0000-000000001001",
+                            ),
+                            StructMapItem(
+                                order=2,
+                                type="structure:page",
+                                label="Page 2",
+                                file_set_id="00000000-0000-0000-0000-000000001002",
+                            ),
+                        ],
+                    )
+                ],
+            ),
+            PackageResource(
+                id=uuid.UUID("00000000-0000-0000-0000-000000001002"),
+                type="File Set",
+                alternate_identifier=[
+                    AlternateIdentifier(id="xyzzy:00000001:00000001", type="DLXS"),
+                    AlternateIdentifier(id="00000000-0000-0000-0000-000000001001", type="function:version"),
+                ],
+                events=[
+                    PreservationEvent(
+                        identifier="fe4c76e5-dbf1-4934-97fb-52ef5a68f073",
+                        type="generate access derivative",
+                        datetime=datetime(1993, 6, 11, 4, 44, 7, tzinfo=UTC),
+                        detail="Night wonder three him family structure simple.",
+                        agent=Agent(
+                            address="arroyoalan@example.net", role="image processing"
+                        ),
+                    ),
+                    PreservationEvent(
+                        identifier="3bdcb1e3-4674-4b9c-83c8-4f9f9fe50812",
+                        type="extract text",
+                        datetime=datetime(1988, 5, 26, 18, 33, 46, tzinfo=UTC),
+                        detail="Player center road attorney speak wait partner.",
+                        agent=Agent(
+                            address="jonathanjones@example.net", role="ocr processing"
+                        ),
+                    ),
+                ],
+                metadata_files=[
+                    FileMetadata(
+                        id="_0193d5f0-7e72-7481-b6fd-0f916c30b396",
+                        use="function:technical",
+                        ref=FileReference(
+                            locref="../metadata/00000001.function:source.format:image.jpg.function:technical.mix.xml",
+                            mdtype="NISOIMG",
+                        ),
+                    ),
+                    FileMetadata(
+                        id="_0193d5f0-7e75-7803-8e41-71323b7b3284",
+                        use="function:technical",
+                        ref=FileReference(
+                            locref="../metadata/00000001.function:service.format:image.jpg.function:technical.mix.xml",
+                            mdtype="NISOIMG",
+                        ),
+                    ),
+                    FileMetadata(
+                        id="_0193d5f0-7f54-7268-b9b1-821085acdcf7",
+                        use="function:technical",
+                        ref=FileReference(
+                            locref="../metadata/00000001.function:service.format:text-plain.txt.function:technical.textmd.xml",
+                            mdtype="TEXTMD",
+                        ),
+                    ),
+                ],
+                data_files=[
+                    FileMetadata(
+                        id="_be653ff450ae7f3520312a53e56c00bc",
+                        mdid="_0193d5f0-7e72-7481-b6fd-0f916c30b396",
+                        use="function:source",
+                        ref=FileReference(
+                            locref="../data/00000001.function:source.format:image.jpg",
+                            mimetype="image/jpeg",
+                        ),
+                    ),
+                    FileMetadata(
+                        id="_7e923d9c33b3859e1327fa53a8e609a1",
+                        groupid="_be653ff450ae7f3520312a53e56c00bc",
+                        mdid="_0193d5f0-7e75-7803-8e41-71323b7b3284",
+                        use="function:service",
+                        ref=FileReference(
+                            locref="../data/00000001.function:service.format:image.jpg",
+                            mimetype="image/jpeg",
+                        ),
+                    ),
+                    FileMetadata(
+                        id="_764ba9761fbc6cbf0462d28d19356148",
+                        groupid="_be653ff450ae7f3520312a53e56c00bc",
+                        mdid="_0193d5f0-7f54-7268-b9b1-821085acdcf7",
+                        use="function:service",
+                        ref=FileReference(
+                            locref="../data/00000001.function:service.format:text-plain.txt",
+                            mimetype="text/plain",
+                        ),
+                    ),
+                ],
+            ),
+        ],
+    )

--- a/conftest.py
+++ b/conftest.py
@@ -73,7 +73,7 @@ def sample_revision() -> Revision:
                 id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
                 type="Monograph",
                 root=True,
-                alternate_identifier=[AlternateIdentifier(
+                alternate_identifiers=[AlternateIdentifier(
                     id="xyzzy:00000001", type="DLXS"
                 )],
                 events=[
@@ -132,7 +132,7 @@ def sample_revision() -> Revision:
             PackageResource(
                 id=uuid.UUID("00000000-0000-0000-0000-000000001001"),
                 type="File Set",
-                alternate_identifier=[AlternateIdentifier(
+                alternate_identifiers=[AlternateIdentifier(
                     id="xyzzy:00000001:00000001", type="DLXS"
                 )],
                 events=[
@@ -225,6 +225,7 @@ def sample_revision_two(sample_revision) -> Revision:
     sample_revision_two.common_metadata["subjects"].append("Something new")
     return sample_revision_two
 
+
 @pytest.fixture
 def referenced_revision() -> Revision:
     return Revision(
@@ -247,7 +248,7 @@ def referenced_revision() -> Revision:
                 id=uuid.UUID("00000000-0000-0000-0000-000000000002"),
                 type="Monograph",
                 root=True,
-                alternate_identifier=[AlternateIdentifier(
+                alternate_identifiers=[AlternateIdentifier(
                     id="xyzzy:00000002", type="DLXS"
                 )],
                 events=[
@@ -306,9 +307,9 @@ def referenced_revision() -> Revision:
             PackageResource(
                 id=uuid.UUID("00000000-0000-0000-0000-000000001002"),
                 type="File Set",
-                alternate_identifier=[
+                alternate_identifiers=[
                     AlternateIdentifier(id="xyzzy:00000001:00000001", type="DLXS"),
-                    AlternateIdentifier(id="00000000-0000-0000-0000-000000001001", type="function:version"),
+                    AlternateIdentifier(id="00000000-0000-0000-0000-000000001001", type="function:copy-of"),
                 ],
                 events=[
                     PreservationEvent(

--- a/dor/builders/parts.py
+++ b/dor/builders/parts.py
@@ -66,6 +66,7 @@ class UseFunction(str, _Enum):
     event = "function:event"
     technical = "function:technical"
     intermediate = "function:intermediate"
+    copy_of = "function:copy-of"
 
 
 class UseFormat(str, _Enum):

--- a/dor/entrypoints/api/catalog.py
+++ b/dor/entrypoints/api/catalog.py
@@ -57,3 +57,19 @@ def get_revision_filesets(file_set_identifier: str, session=Depends(get_db_sessi
         return JSONResponse(status_code=status.HTTP_200_OK, content=mapping)
     else:
         return JSONResponse(status_code=status.HTTP_404_NOT_FOUND, content="No items were found")
+
+
+@catalog_router.get("/revisions/search/file_set/{file_set_identifier}")
+def get_revision_filesets(file_set_identifier: str, session=Depends(get_db_session)) -> JSONResponse:
+    try:
+        uuid_identifier = uuid.UUID(file_set_identifier)
+    except ValueError:
+        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content="File set identifier is not a valid UUID.")
+
+    catalog = SqlalchemyCatalog(session)
+    revisions = catalog.find_by_file_set(str(uuid_identifier))
+    if len(revisions):
+        summaries = catalog_service.summarize_with_file_sets(revisions, uuid_identifier)
+        return JSONResponse(status_code=status.HTTP_200_OK, content=summaries)
+    else:
+        return JSONResponse(status_code=status.HTTP_404_NOT_FOUND, content="No items were found")

--- a/dor/entrypoints/api/catalog.py
+++ b/dor/entrypoints/api/catalog.py
@@ -12,7 +12,7 @@ catalog_router = APIRouter(prefix="/catalog")
 
 
 @catalog_router.get("/revisions/{identifier}/")
-def get_revision_summary(identifier: str, session = Depends(get_db_session)) -> JSONResponse:
+def get_revision_summary(identifier: str, session=Depends(get_db_session)) -> JSONResponse:
     try:
         uuid_identifier = uuid.UUID(identifier)
     except ValueError:
@@ -28,7 +28,7 @@ def get_revision_summary(identifier: str, session = Depends(get_db_session)) -> 
 
 
 @catalog_router.get("/revisions/{identifier}/filesets")
-def get_revision_filesets(identifier: str, session = Depends(get_db_session)) -> JSONResponse:
+def get_revision_filesets(identifier: str, session=Depends(get_db_session)) -> JSONResponse:
     try:
         uuid_identifier = uuid.UUID(identifier)
     except ValueError:
@@ -41,3 +41,19 @@ def get_revision_filesets(identifier: str, session = Depends(get_db_session)) ->
         return JSONResponse(status_code=status.HTTP_200_OK, content=filesets)
     else:
         return JSONResponse(status_code=status.HTTP_404_NOT_FOUND, content="Item not found")
+
+
+@catalog_router.get("/revisions/index/{file_set_identifier}")
+def get_revision_filesets(file_set_identifier: str, session=Depends(get_db_session)) -> JSONResponse:
+    try:
+        uuid_identifier = uuid.UUID(file_set_identifier)
+    except ValueError:
+        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content="File set identifier is not a valid UUID.")
+
+    catalog = SqlalchemyCatalog(session)
+    revisions = catalog.find_by_file_set(str(uuid_identifier))
+    if len(revisions):
+        mapping = catalog_service.index_by_file_set(revisions, uuid_identifier)
+        return JSONResponse(status_code=status.HTTP_200_OK, content=mapping)
+    else:
+        return JSONResponse(status_code=status.HTTP_404_NOT_FOUND, content="No items were found")

--- a/dor/entrypoints/api/catalog.py
+++ b/dor/entrypoints/api/catalog.py
@@ -43,8 +43,8 @@ def get_revision_filesets(identifier: str, session=Depends(get_db_session)) -> J
         return JSONResponse(status_code=status.HTTP_404_NOT_FOUND, content="Item not found")
 
 
-@catalog_router.get("/revisions/index/{file_set_identifier}")
-def get_revision_filesets(file_set_identifier: str, session=Depends(get_db_session)) -> JSONResponse:
+@catalog_router.get("/revisions/search/file_set/{file_set_identifier}")
+def get_revision_by_fileset(file_set_identifier: str, session=Depends(get_db_session)) -> JSONResponse:
     try:
         uuid_identifier = uuid.UUID(file_set_identifier)
     except ValueError:
@@ -53,23 +53,9 @@ def get_revision_filesets(file_set_identifier: str, session=Depends(get_db_sessi
     catalog = SqlalchemyCatalog(session)
     revisions = catalog.find_by_file_set(str(uuid_identifier))
     if len(revisions):
-        mapping = catalog_service.index_by_file_set(revisions, uuid_identifier)
+        mapping = catalog_service.summarize_by_file_set(revisions, uuid_identifier)
         return JSONResponse(status_code=status.HTTP_200_OK, content=mapping)
     else:
         return JSONResponse(status_code=status.HTTP_404_NOT_FOUND, content="No items were found")
 
 
-@catalog_router.get("/revisions/search/file_set/{file_set_identifier}")
-def get_revision_filesets(file_set_identifier: str, session=Depends(get_db_session)) -> JSONResponse:
-    try:
-        uuid_identifier = uuid.UUID(file_set_identifier)
-    except ValueError:
-        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content="File set identifier is not a valid UUID.")
-
-    catalog = SqlalchemyCatalog(session)
-    revisions = catalog.find_by_file_set(str(uuid_identifier))
-    if len(revisions):
-        summaries = catalog_service.summarize_with_file_sets(revisions, uuid_identifier)
-        return JSONResponse(status_code=status.HTTP_200_OK, content=summaries)
-    else:
-        return JSONResponse(status_code=status.HTTP_404_NOT_FOUND, content="No items were found")

--- a/dor/providers/accumulator.py
+++ b/dor/providers/accumulator.py
@@ -7,7 +7,7 @@ from dor.adapters.technical_metadata import TechnicalMetadata
 from dor.builders.parts import (
     FileInfo,
     flatten_use,
-    MetadataFileInfo, 
+    MetadataFileInfo,
     UseFormat,
     UseFunction
 )
@@ -180,9 +180,9 @@ def create_package_resource(
     resource = PackageResource(
         id=file_set_identifier.uuid,
         type="File Set",
-        alternate_identifier=AlternateIdentifier(
+        alternate_identifiers=[AlternateIdentifier(
             id=file_set_identifier.alternate_identifier, type="DLXS"
-        ),
+        )],
         events=[],
         metadata_files=[
             convert_metadata_file_info_to_file_metadata(metadata_file_info)

--- a/dor/providers/models.py
+++ b/dor/providers/models.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from enum import Enum
 from pathlib import Path
 
+
 class _Enum(Enum):
     def __str__(self):
         return self.value
@@ -74,7 +75,7 @@ class StructMap:
 class PackageResource:
     id: uuid.UUID
     type: str
-    alternate_identifier: list[AlternateIdentifier] = field(default_factory=list)
+    alternate_identifiers: list[AlternateIdentifier] = field(default_factory=list)
     events: list[PreservationEvent] = field(default_factory=list)
     metadata_files: list[FileMetadata] = field(default_factory=list)
     data_files: list[FileMetadata] = field(default_factory=list)
@@ -93,7 +94,7 @@ class PackageResource:
         return entries
 
     def has_alternate_identifier(self, identifier: AlternateIdentifier) -> bool:
-        for alt_identifier in self.alternate_identifier:
+        for alt_identifier in self.alternate_identifiers:
             if alt_identifier == identifier:
                 return True
         return False

--- a/dor/providers/models.py
+++ b/dor/providers/models.py
@@ -74,8 +74,8 @@ class StructMap:
 class PackageResource:
     id: uuid.UUID
     type: str
-    alternate_identifier: AlternateIdentifier
-    events: list[PreservationEvent]
+    alternate_identifier: list[AlternateIdentifier] = field(default_factory=list)
+    events: list[PreservationEvent] = field(default_factory=list)
     metadata_files: list[FileMetadata] = field(default_factory=list)
     data_files: list[FileMetadata] = field(default_factory=list)
     struct_maps: list[StructMap] = field(default_factory=list)
@@ -91,3 +91,9 @@ class PackageResource:
             entries.append(Path(file_metadata.ref.locref))
 
         return entries
+
+    def has_alternate_identifier(self, identifier: AlternateIdentifier) -> bool:
+        for alt_identifier in self.alternate_identifier:
+            if alt_identifier == identifier:
+                return True
+        return False

--- a/dor/providers/package_generator.py
+++ b/dor/providers/package_generator.py
@@ -192,7 +192,7 @@ class PackageGenerator:
         with (descriptor_path / descriptor_file_name).open("w") as file:
             file.write(xmldata)
 
-    def generate(self) -> PackageResult:        
+    def generate(self) -> PackageResult:
         # Validate metadata?
 
         self.file_provider.create_directory(self.package_path)
@@ -231,7 +231,8 @@ class PackageGenerator:
         try:
             descriptive_data = self.get_metadata_file_data(use="function:source")
             descriptive_file_path = self.get_metadata_file_path(".function:source.json")
-            descriptive_file_metadata = self.get_file_metadata(file_path=descriptive_file_path, metadata_data=descriptive_data)
+            descriptive_file_metadata = self.get_file_metadata(
+                file_path=descriptive_file_path, metadata_data=descriptive_data)
             self.create_root_metadata_file(
                 file_path=descriptive_file_path,
                 data=descriptive_data["data"],
@@ -251,7 +252,8 @@ class PackageGenerator:
 
             provenance_data = self.get_metadata_file_data(use="function:provenance")
             provenance_file_path = self.get_metadata_file_path(".function:provenance.premis.xml")
-            provenance_file_metadata = self.get_file_metadata(file_path=provenance_file_path, metadata_data=provenance_data)
+            provenance_file_metadata = self.get_file_metadata(
+                file_path=provenance_file_path, metadata_data=provenance_data)
             self.create_root_metadata_file(
                 file_path=provenance_file_path,
                 data=provenance_data["data"],
@@ -267,9 +269,9 @@ class PackageGenerator:
             id=uuid.UUID(self.root_resource_identifier),
             type=self.type,
             root=True,
-            alternate_identifier=AlternateIdentifier(
+            alternate_identifiers=[AlternateIdentifier(
                 id=alternate_identifier, type="DLXS"
-            ),
+            )],
             events=[],
             metadata_files=metadata_file_metadatas,
             data_files=[],

--- a/dor/providers/package_resources_merger.py
+++ b/dor/providers/package_resources_merger.py
@@ -1,5 +1,6 @@
 from dor.providers.models import PackageResource, StructMapType
 
+
 class PackageResourcesMerger:
     def __init__(self, incoming: list[PackageResource], current: list[PackageResource]):
         self.incoming = incoming
@@ -64,7 +65,7 @@ class PackageResourcesMerger:
         return PackageResource(
             id=incoming_resource.id,
             type=incoming_resource.type,
-            alternate_identifier=incoming_resource.alternate_identifier,
+            alternate_identifiers=incoming_resource.alternate_identifiers,
             events=merged_events,
             metadata_files=merged_metadata_files,
             data_files=merged_data_files,
@@ -76,7 +77,8 @@ class PackageResourcesMerger:
         index = self._index(b, attr)
         for value in a + b:
             key = getattr(value, attr)
-            if value in merged: continue
+            if value in merged:
+                continue
             elif key in index:
                 merged.append(index[key])
             elif not value in merged:
@@ -88,10 +90,11 @@ class PackageResourcesMerger:
         index = {}
         for value in b:
             index[value.ref.locref] = value
-        
+
         for value in a + b:
             key = value.ref.locref
-            if value in merged: continue
+            if value in merged:
+                continue
             elif key in index:
                 merged.append(index[key])
             elif not value in merged:

--- a/dor/providers/parsers.py
+++ b/dor/providers/parsers.py
@@ -62,7 +62,7 @@ class DescriptorFileParser:
         record_status = header.get_optional("RECORDSTATUS")
         return record_status == "root"
 
-    def get_alternate_identifier(self) -> list[AlternateIdentifier]:
+    def get_alternate_identifiers(self) -> list[AlternateIdentifier]:
         return [
             AlternateIdentifier(type=elem.get('TYPE'), id=elem.text)
             for elem in self.tree.findall("METS:metsHdr/METS:altRecordID")

--- a/dor/providers/parsers.py
+++ b/dor/providers/parsers.py
@@ -62,11 +62,11 @@ class DescriptorFileParser:
         record_status = header.get_optional("RECORDSTATUS")
         return record_status == "root"
 
-    def get_alternate_identifier(self) -> AlternateIdentifier:
-        alt_record_id = self.tree.find("METS:metsHdr/METS:altRecordID")
-        return AlternateIdentifier(
-            type=alt_record_id.get("TYPE"), id=alt_record_id.text
-        )
+    def get_alternate_identifier(self) -> list[AlternateIdentifier]:
+        return [
+            AlternateIdentifier(type=elem.get('TYPE'), id=elem.text)
+            for elem in self.tree.findall("METS:metsHdr/METS:altRecordID")
+        ]
 
     def get_preservation_event_paths(self) -> list[str]:
         locrefs = []

--- a/dor/providers/resource_provider.py
+++ b/dor/providers/resource_provider.py
@@ -13,7 +13,7 @@ class ResourceProvider:
 
     def __init__(self, file_provider: FileProvider, resource_path: Path):
         self.file_provider: FileProvider = file_provider
-        self.resource_path: Path = resource_path 
+        self.resource_path: Path = resource_path
 
     def get_descriptor_path(self) -> Path:
         file_paths = list((self.resource_path / "descriptor").iterdir())
@@ -34,7 +34,7 @@ class ResourceProvider:
 
         return PackageResource(
             id=descriptor_file_parser.get_id(),
-            alternate_identifier=descriptor_file_parser.get_alternate_identifier(),
+            alternate_identifiers=descriptor_file_parser.get_alternate_identifiers(),
             type=descriptor_file_parser.get_type(),
             root=descriptor_file_parser.get_root(),
             events=pres_events,

--- a/dor/service_layer/catalog_service.py
+++ b/dor/service_layer/catalog_service.py
@@ -16,17 +16,6 @@ def summarize(revision: Revision):
     ))
 
 
-def extract_matching_filesets(revision: Revision, file_set_identifier: uuid.UUID):
-    referenced_file_set_identifier = AlternateIdentifier(
-        type=UseFunction.copy_of.value,
-        id=str(file_set_identifier)
-    )
-    return [
-        str(resource.id)
-        for resource in revision.package_resources
-        if resource.id == file_set_identifier or referenced_file_set_identifier in resource.alternate_identifiers
-    ][0]
-
 def get_file_sets(revision: Revision):
     return [
         converter.unstructure(resource)
@@ -34,7 +23,7 @@ def get_file_sets(revision: Revision):
     ]
 
 
-def index_by_file_set(revisions: list[Revision], file_set_identifier: str):
+def summarize_by_file_set(revisions: list[Revision], file_set_identifier: str):
     key = str(file_set_identifier)
     mapping = {key: []}
     referenced_file_set_identifier = AlternateIdentifier(
@@ -53,11 +42,3 @@ def index_by_file_set(revisions: list[Revision], file_set_identifier: str):
 
     return mapping
 
-
-def summarize_with_file_sets(revisions: list[Revision], file_set_identifier: uuid.UUID):
-    summaries = []
-    for revision in revisions:
-        summary = summarize(revision)
-        summary['file_set_identifier'] = extract_matching_filesets(revision, file_set_identifier)
-        summaries.append(summary)
-    return summaries

--- a/dor/service_layer/catalog_service.py
+++ b/dor/service_layer/catalog_service.py
@@ -16,7 +16,7 @@ def summarize(revision: Revision):
     ))
 
 
-def summarize_filesets(revision: Revision, file_set_identifier: uuid.UUID):
+def extract_matching_filesets(revision: Revision, file_set_identifier: uuid.UUID):
     referenced_file_set_identifier = AlternateIdentifier(
         type=UseFunction.copy_of.value,
         id=str(file_set_identifier)
@@ -25,7 +25,7 @@ def summarize_filesets(revision: Revision, file_set_identifier: uuid.UUID):
         str(resource.id)
         for resource in revision.package_resources
         if resource.id == file_set_identifier or referenced_file_set_identifier in resource.alternate_identifiers
-    ]
+    ][0]
 
 def get_file_sets(revision: Revision):
     return [
@@ -58,6 +58,6 @@ def summarize_with_file_sets(revisions: list[Revision], file_set_identifier: uui
     summaries = []
     for revision in revisions:
         summary = summarize(revision)
-        summary['file_sets'] = summarize_filesets(revision, file_set_identifier)
+        summary['file_set_identifier'] = extract_matching_filesets(revision, file_set_identifier)
         summaries.append(summary)
     return summaries

--- a/dor/service_layer/catalog_service.py
+++ b/dor/service_layer/catalog_service.py
@@ -1,3 +1,4 @@
+import uuid
 from dor.adapters.converter import converter
 
 from dor.builders.parts import UseFunction
@@ -14,6 +15,17 @@ def summarize(revision: Revision):
         common_metadata=revision.common_metadata
     ))
 
+
+def summarize_filesets(revision: Revision, file_set_identifier: uuid.UUID):
+    referenced_file_set_identifier = AlternateIdentifier(
+        type=UseFunction.copy_of.value,
+        id=str(file_set_identifier)
+    )
+    return [
+        str(resource.id)
+        for resource in revision.package_resources
+        if resource.id == file_set_identifier or referenced_file_set_identifier in resource.alternate_identifiers
+    ]
 
 def get_file_sets(revision: Revision):
     return [
@@ -40,3 +52,12 @@ def index_by_file_set(revisions: list[Revision], file_set_identifier: str):
                 ))
 
     return mapping
+
+
+def summarize_with_file_sets(revisions: list[Revision], file_set_identifier: uuid.UUID):
+    summaries = []
+    for revision in revisions:
+        summary = summarize(revision)
+        summary['file_sets'] = summarize_filesets(revision, file_set_identifier)
+        summaries.append(summary)
+    return summaries

--- a/dor/service_layer/catalog_service.py
+++ b/dor/service_layer/catalog_service.py
@@ -1,6 +1,8 @@
 from dor.adapters.converter import converter
 
+from dor.builders.parts import UseFunction
 from dor.domain.models import Revision
+from dor.providers.models import AlternateIdentifier
 
 
 def summarize(revision: Revision):
@@ -12,8 +14,29 @@ def summarize(revision: Revision):
         common_metadata=revision.common_metadata
     ))
 
+
 def get_file_sets(revision: Revision):
     return [
         converter.unstructure(resource)
         for resource in revision.package_resources if resource.type == 'File Set'
     ]
+
+
+def index_by_file_set(revisions: list[Revision], file_set_identifier: str):
+    key = str(file_set_identifier)
+    mapping = {key: []}
+    referenced_file_set_identifier = AlternateIdentifier(
+        type=UseFunction.copy_of.value,
+        id=str(file_set_identifier)
+    )
+
+    for revision in revisions:
+        for resource in revision.package_resources:
+            if resource.id == file_set_identifier or \
+                    referenced_file_set_identifier in resource.alternate_identifiers:
+                mapping[key].append(dict(
+                    file_set_identifier=str(resource.id),
+                    bin_identifier=str(revision.identifier)
+                ))
+
+    return mapping

--- a/dor/service_layer/handlers/catalog_revision.py
+++ b/dor/service_layer/handlers/catalog_revision.py
@@ -6,11 +6,12 @@ from dor.domain.events import PackageStored, RevisionCataloged
 from dor.domain.models import Revision
 from dor.service_layer.unit_of_work import AbstractUnitOfWork
 
+
 def catalog_revision(event: PackageStored, uow: AbstractUnitOfWork) -> None:
     root_resource = [resource for resource in event.resources if resource.type == 'Monograph'][0]
     common_metadata_file = [
         metadata_file for metadata_file in root_resource.metadata_files
-            if metadata_file.use == 'function:service' and metadata_file.ref.mdtype == 'schema:common'
+        if metadata_file.use == 'function:service' and metadata_file.ref.mdtype == 'schema:common'
     ][0]
     common_metadata_file_path = Path(common_metadata_file.ref.locref)
     object_files = uow.gateway.get_object_files(event.identifier)
@@ -22,7 +23,7 @@ def catalog_revision(event: PackageStored, uow: AbstractUnitOfWork) -> None:
 
     revision = Revision(
         identifier=event.identifier,
-        alternate_identifiers=[alt_identifier.id for alt_identifier in root_resource.alternate_identifier],
+        alternate_identifiers=[alt_identifier.id for alt_identifier in root_resource.alternate_identifiers],
         revision_number=event.revision_number,
         created_at=datetime.now(tz=UTC),
         common_metadata=common_metadata,
@@ -38,4 +39,3 @@ def catalog_revision(event: PackageStored, uow: AbstractUnitOfWork) -> None:
         tracking_identifier=event.tracking_identifier,
         package_identifier=event.package_identifier
     ))
-    

--- a/dor/service_layer/handlers/catalog_revision.py
+++ b/dor/service_layer/handlers/catalog_revision.py
@@ -22,7 +22,7 @@ def catalog_revision(event: PackageStored, uow: AbstractUnitOfWork) -> None:
 
     revision = Revision(
         identifier=event.identifier,
-        alternate_identifiers=[root_resource.alternate_identifier.id],
+        alternate_identifiers=[alt_identifier.id for alt_identifier in root_resource.alternate_identifier],
         revision_number=event.revision_number,
         created_at=datetime.now(tz=UTC),
         common_metadata=common_metadata,

--- a/features/steps/test_inspect_revision.py
+++ b/features/steps/test_inspect_revision.py
@@ -53,7 +53,7 @@ def _(alt_id, unit_of_work: AbstractUnitOfWork):
                 id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
                 type="Monograph",
                 root=True,
-                alternate_identifier=[AlternateIdentifier(
+                alternate_identifiers=[AlternateIdentifier(
                     id="xyzzy:00000001", type="DLXS"
                 )],
                 events=[
@@ -112,7 +112,7 @@ def _(alt_id, unit_of_work: AbstractUnitOfWork):
             PackageResource(
                 id=uuid.UUID("00000000-0000-0000-0000-000000001001"),
                 type="File Set",
-                alternate_identifier=[AlternateIdentifier(
+                alternate_identifiers=[AlternateIdentifier(
                     id="xyzzy:00000001:00000001", type="DLXS"
                 )],
                 events=[

--- a/features/steps/test_inspect_revision.py
+++ b/features/steps/test_inspect_revision.py
@@ -53,9 +53,9 @@ def _(alt_id, unit_of_work: AbstractUnitOfWork):
                 id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
                 type="Monograph",
                 root=True,
-                alternate_identifier=AlternateIdentifier(
+                alternate_identifier=[AlternateIdentifier(
                     id="xyzzy:00000001", type="DLXS"
-                ),
+                )],
                 events=[
                     PreservationEvent(
                         identifier="abdcb901-721a-4be0-a981-14f514236633",
@@ -112,9 +112,9 @@ def _(alt_id, unit_of_work: AbstractUnitOfWork):
             PackageResource(
                 id=uuid.UUID("00000000-0000-0000-0000-000000001001"),
                 type="File Set",
-                alternate_identifier=AlternateIdentifier(
+                alternate_identifier=[AlternateIdentifier(
                     id="xyzzy:00000001:00000001", type="DLXS"
-                ),
+                )],
                 events=[
                     PreservationEvent(
                         identifier="fe4c76e5-dbf1-4934-97fb-52ef5a68f073",

--- a/templates/preservation_mets.xml
+++ b/templates/preservation_mets.xml
@@ -5,9 +5,9 @@
     <METS:agent ROLE="CREATOR" TYPE="ORGANIZATION">
       <METS:name>University of Michigan - Library Information Technology - Digital Collection Services</METS:name>
     </METS:agent>
-    {% if resource.alternate_identifier %}
-    <METS:altRecordID TYPE="{{ resource.alternate_identifier.type }}">{{ resource.alternate_identifier.id }}</METS:altRecordID>
-    {% endif %}
+    {% for alternate_identifier in resource.alternate_identifiers %}
+    <METS:altRecordID TYPE="{{ alternate_identifier.type }}">{{ alternate_identifier.id }}</METS:altRecordID>
+    {% endfor %}
   </METS:metsHdr>
 
   {% include "partials/_md_sec.fragment.xml" %}

--- a/tests/e2e/test_catalog_api.py
+++ b/tests/e2e/test_catalog_api.py
@@ -114,11 +114,11 @@ def test_catalog_search_with_file_sets(sample_revision, referenced_revision, db_
             created_at=sample_revision.created_at,
             alternate_identifiers=sample_revision.alternate_identifiers,
             common_metadata=sample_revision.common_metadata,
-            file_sets=[
+            file_set_identifier=[
                 str(resource.id)
                 for resource in sample_revision.package_resources
                 if str(resource.id) == file_set_identifier or referenced_file_set_identifier in resource.alternate_identifiers
-            ]
+            ][0]
         )),
         converter.unstructure(dict(
             identifier=referenced_revision.identifier,
@@ -126,14 +126,12 @@ def test_catalog_search_with_file_sets(sample_revision, referenced_revision, db_
             created_at=referenced_revision.created_at,
             alternate_identifiers=referenced_revision.alternate_identifiers,
             common_metadata=referenced_revision.common_metadata,
-            file_sets=[
+            file_set_identifier=[
                 str(resource.id)
                 for resource in referenced_revision.package_resources
                 if resource.id == file_set_identifier or referenced_file_set_identifier in resource.alternate_identifiers
-            ]
+            ][0]
         )),
     ]
-
-    print(response.json())
 
     assert response.json() == expected_summaries

--- a/tests/e2e/test_catalog_api.py
+++ b/tests/e2e/test_catalog_api.py
@@ -6,7 +6,6 @@ from dor.adapters.converter import converter
 from dor.builders.parts import UseFunction
 from dor.domain.models import Revision
 from dor.providers.models import AlternateIdentifier
-from dor.service_layer.catalog_service import summarize_with_file_sets
 
 
 @pytest.mark.usefixtures("sample_revision", "db_session", "test_client")
@@ -48,7 +47,7 @@ def test_catalog_api_returns_200_and_file_sets(
 
 
 @pytest.mark.usefixtures("sample_revision", "referenced_revision", "db_session", "test_client")
-def test_catalog_api_returns_200_and_index_by_file_set(
+def test_catalog_api_returns_200_and_summarize_by_file_set(
     sample_revision: Revision, referenced_revision: Revision, db_session, test_client
 ) -> None:
     catalog = SqlalchemyCatalog(db_session)
@@ -60,7 +59,7 @@ def test_catalog_api_returns_200_and_index_by_file_set(
         db_session.commit()
 
     file_set_identifier = "00000000-0000-0000-0000-000000001001"
-    response = test_client.get(f"/api/v1/catalog/revisions/index/{file_set_identifier}")
+    response = test_client.get(f"/api/v1/catalog/revisions/search/file_set/{file_set_identifier}")
 
     assert response.status_code == 200
 
@@ -84,54 +83,3 @@ def test_catalog_api_returns_200_and_index_by_file_set(
 
     assert response.json() == expected_mapping
 
-
-@pytest.mark.usefixtures("sample_revision", "referenced_revision", "db_session", "test_client")
-def test_catalog_search_with_file_sets(sample_revision, referenced_revision, db_session, test_client
-) -> None:
-    file_set_identifier = "00000000-0000-0000-0000-000000001001"
-
-    catalog = SqlalchemyCatalog(db_session)
-    with db_session.begin():
-        catalog.add(sample_revision)
-        db_session.commit()
-    with db_session.begin():
-        catalog.add(referenced_revision)
-        db_session.commit()
-
-    file_set_identifier = "00000000-0000-0000-0000-000000001001"
-    response = test_client.get(f"/api/v1/catalog/revisions/search/file_set/{file_set_identifier}")
-
-    assert response.status_code == 200
-
-    referenced_file_set_identifier = AlternateIdentifier(
-        type=UseFunction.copy_of.value,
-        id=file_set_identifier
-    )
-    expected_summaries = [
-        converter.unstructure(dict(
-            identifier=sample_revision.identifier,
-            revision_number=sample_revision.revision_number,
-            created_at=sample_revision.created_at,
-            alternate_identifiers=sample_revision.alternate_identifiers,
-            common_metadata=sample_revision.common_metadata,
-            file_set_identifier=[
-                str(resource.id)
-                for resource in sample_revision.package_resources
-                if str(resource.id) == file_set_identifier or referenced_file_set_identifier in resource.alternate_identifiers
-            ][0]
-        )),
-        converter.unstructure(dict(
-            identifier=referenced_revision.identifier,
-            revision_number=referenced_revision.revision_number,
-            created_at=referenced_revision.created_at,
-            alternate_identifiers=referenced_revision.alternate_identifiers,
-            common_metadata=referenced_revision.common_metadata,
-            file_set_identifier=[
-                str(resource.id)
-                for resource in referenced_revision.package_resources
-                if resource.id == file_set_identifier or referenced_file_set_identifier in resource.alternate_identifiers
-            ][0]
-        )),
-    ]
-
-    assert response.json() == expected_summaries

--- a/tests/e2e/test_catalog_api.py
+++ b/tests/e2e/test_catalog_api.py
@@ -1,3 +1,4 @@
+import uuid
 import pytest
 
 from dor.adapters.catalog import SqlalchemyCatalog
@@ -5,6 +6,7 @@ from dor.adapters.converter import converter
 from dor.builders.parts import UseFunction
 from dor.domain.models import Revision
 from dor.providers.models import AlternateIdentifier
+from dor.service_layer.catalog_service import summarize_with_file_sets
 
 
 @pytest.mark.usefixtures("sample_revision", "db_session", "test_client")
@@ -81,3 +83,57 @@ def test_catalog_api_returns_200_and_index_by_file_set(
     }
 
     assert response.json() == expected_mapping
+
+
+@pytest.mark.usefixtures("sample_revision", "referenced_revision", "db_session", "test_client")
+def test_catalog_search_with_file_sets(sample_revision, referenced_revision, db_session, test_client
+) -> None:
+    file_set_identifier = "00000000-0000-0000-0000-000000001001"
+
+    catalog = SqlalchemyCatalog(db_session)
+    with db_session.begin():
+        catalog.add(sample_revision)
+        db_session.commit()
+    with db_session.begin():
+        catalog.add(referenced_revision)
+        db_session.commit()
+
+    file_set_identifier = "00000000-0000-0000-0000-000000001001"
+    response = test_client.get(f"/api/v1/catalog/revisions/search/file_set/{file_set_identifier}")
+
+    assert response.status_code == 200
+
+    referenced_file_set_identifier = AlternateIdentifier(
+        type=UseFunction.copy_of.value,
+        id=file_set_identifier
+    )
+    expected_summaries = [
+        converter.unstructure(dict(
+            identifier=sample_revision.identifier,
+            revision_number=sample_revision.revision_number,
+            created_at=sample_revision.created_at,
+            alternate_identifiers=sample_revision.alternate_identifiers,
+            common_metadata=sample_revision.common_metadata,
+            file_sets=[
+                str(resource.id)
+                for resource in sample_revision.package_resources
+                if str(resource.id) == file_set_identifier or referenced_file_set_identifier in resource.alternate_identifiers
+            ]
+        )),
+        converter.unstructure(dict(
+            identifier=referenced_revision.identifier,
+            revision_number=referenced_revision.revision_number,
+            created_at=referenced_revision.created_at,
+            alternate_identifiers=referenced_revision.alternate_identifiers,
+            common_metadata=referenced_revision.common_metadata,
+            file_sets=[
+                str(resource.id)
+                for resource in referenced_revision.package_resources
+                if resource.id == file_set_identifier or referenced_file_set_identifier in resource.alternate_identifiers
+            ]
+        )),
+    ]
+
+    print(response.json())
+
+    assert response.json() == expected_summaries

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -14,6 +14,7 @@ def test_memory_catalog_adds_revision(sample_revision) -> None:
     assert len(catalog.revisions) == 1
     assert catalog.revisions[0] == sample_revision
 
+
 @pytest.mark.usefixtures("sample_revision")
 def test_memory_catalog_gets_revision(sample_revision) -> None:
     catalog = MemoryCatalog()
@@ -21,6 +22,7 @@ def test_memory_catalog_gets_revision(sample_revision) -> None:
 
     revision = catalog.get("00000000-0000-0000-0000-000000000001")
     assert revision == sample_revision
+
 
 @pytest.mark.usefixtures("sample_revision", "sample_revision_two")
 def test_memory_catalog_returns_latest_revision(sample_revision, sample_revision_two) -> None:
@@ -31,6 +33,7 @@ def test_memory_catalog_returns_latest_revision(sample_revision, sample_revision
     revision = catalog.get("00000000-0000-0000-0000-000000000001")
     assert revision == sample_revision_two
 
+
 @pytest.mark.usefixtures("sample_revision")
 def test_memory_catalog_gets_by_alternate_identifier(sample_revision) -> None:
     catalog = MemoryCatalog()
@@ -38,6 +41,7 @@ def test_memory_catalog_gets_by_alternate_identifier(sample_revision) -> None:
 
     revision = catalog.get_by_alternate_identifier("xyzzy:00000001")
     assert revision == sample_revision
+
 
 @pytest.mark.usefixtures("sample_revision", "sample_revision_two")
 def test_memory_catalog_returns_latest_for_alternate_identifier(
@@ -50,6 +54,7 @@ def test_memory_catalog_returns_latest_for_alternate_identifier(
     revision = catalog.get_by_alternate_identifier("xyzzy:00000001")
     assert revision == sample_revision_two
 
+
 @pytest.mark.usefixtures("sample_revision", "referenced_revision")
 def test_memory_catalog_returns_latest_by_file_set_identifier(
     sample_revision, referenced_revision
@@ -61,6 +66,7 @@ def test_memory_catalog_returns_latest_by_file_set_identifier(
     revisions = catalog.find_by_file_set("00000000-0000-0000-0000-000000001001")
     assert sample_revision in revisions
     assert referenced_revision in revisions
+
 
 @pytest.mark.usefixtures("sample_revision", "sample_revision_two")
 def test_memory_catalog_gets_revisions(
@@ -88,7 +94,7 @@ def test_catalog_adds_revision(db_session, sample_revision) -> None:
             select *
             from catalog_revision
             where identifier = :identifier
-        """), { "identifier": "00000000-0000-0000-0000-000000000001" })
+        """), {"identifier": "00000000-0000-0000-0000-000000000001"})
     )
     assert len(rows) == 1
     assert str(rows[0].identifier) == "00000000-0000-0000-0000-000000000001"
@@ -99,11 +105,12 @@ def test_catalog_adds_revision(db_session, sample_revision) -> None:
             select *
             from catalog_current_revision
             where identifier = :identifier
-        """), { "identifier": "00000000-0000-0000-0000-000000000001" })
+        """), {"identifier": "00000000-0000-0000-0000-000000000001"})
     )
     assert len(rows) == 1
     assert str(rows[0].identifier) == "00000000-0000-0000-0000-000000000001"
     assert rows[0].revision_number == 1
+
 
 @pytest.mark.usefixtures("db_session", "sample_revision", "sample_revision_two")
 def test_catalog_accumulates_revision_and_updates_current_revision(
@@ -123,7 +130,7 @@ def test_catalog_accumulates_revision_and_updates_current_revision(
             select *
             from catalog_revision
             where identifier = :identifier
-        """), { "identifier": "00000000-0000-0000-0000-000000000001" })
+        """), {"identifier": "00000000-0000-0000-0000-000000000001"})
     )
     assert len(rows) == 2
 
@@ -132,12 +139,13 @@ def test_catalog_accumulates_revision_and_updates_current_revision(
             select *
             from catalog_current_revision
             where identifier = :identifier
-        """), { "identifier": "00000000-0000-0000-0000-000000000001" })
+        """), {"identifier": "00000000-0000-0000-0000-000000000001"})
     )
     assert len(rows) == 1
     assert str(rows[0].identifier) == "00000000-0000-0000-0000-000000000001"
     assert rows[0].revision_number == 2
     assert rows[0].common_metadata == sample_revision_two.common_metadata
+
 
 @pytest.mark.usefixtures("db_session", "sample_revision")
 def test_catalog_gets_revision(db_session, sample_revision) -> None:
@@ -148,6 +156,7 @@ def test_catalog_gets_revision(db_session, sample_revision) -> None:
 
     revision = catalog.get("00000000-0000-0000-0000-000000000001")
     assert revision == sample_revision
+
 
 @pytest.mark.usefixtures("db_session", "sample_revision", "sample_revision_two")
 def test_catalog_returns_latest_revision(
@@ -165,6 +174,7 @@ def test_catalog_returns_latest_revision(
     revision = catalog.get("00000000-0000-0000-0000-000000000001")
     assert revision == sample_revision_two
 
+
 @pytest.mark.usefixtures("db_session", "sample_revision")
 def test_catalog_gets_by_alternate_identifier(db_session, sample_revision) -> None:
     catalog = SqlalchemyCatalog(db_session)
@@ -174,6 +184,7 @@ def test_catalog_gets_by_alternate_identifier(db_session, sample_revision) -> No
 
     revision = catalog.get_by_alternate_identifier("xyzzy:00000001")
     assert revision == sample_revision
+
 
 @pytest.mark.usefixtures("db_session", "sample_revision", "sample_revision_two")
 def test_catalog_returns_latest_for_alternate_identifier(
@@ -191,6 +202,7 @@ def test_catalog_returns_latest_for_alternate_identifier(
     revision = catalog.get_by_alternate_identifier("xyzzy:00000001")
     assert revision == sample_revision_two
 
+
 @pytest.mark.usefixtures("db_session", "sample_revision")
 def test_catalog_returns_none_when_no_alternate_identifier_matches(db_session, sample_revision) -> None:
     catalog = SqlalchemyCatalog(db_session)
@@ -200,6 +212,7 @@ def test_catalog_returns_none_when_no_alternate_identifier_matches(db_session, s
 
     revision = catalog.get_by_alternate_identifier("xyzzy:00000001.404")
     assert revision is None
+
 
 @pytest.mark.usefixtures("db_session", "sample_revision", "referenced_revision")
 def test_catalog_returns_latest_for_alternate_identifier(
@@ -215,8 +228,10 @@ def test_catalog_returns_latest_for_alternate_identifier(
         db_session.commit()
 
     revisions = catalog.find_by_file_set("00000000-0000-0000-0000-000000001001")
+
     assert sample_revision in revisions
     assert referenced_revision in revisions
+
 
 @pytest.mark.usefixtures("db_session", "sample_revision", "sample_revision_two")
 def test_catalog_gets_revisions(
@@ -233,6 +248,7 @@ def test_catalog_gets_revisions(
 
     revisions = catalog.get_revisions("00000000-0000-0000-0000-000000000001")
     assert revisions == [sample_revision, sample_revision_two]
+
 
 @pytest.mark.usefixtures("db_session")
 def test_catalog_returns_empty_array_when_no_revisions_exist(db_session) -> None:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -50,6 +50,18 @@ def test_memory_catalog_returns_latest_for_alternate_identifier(
     revision = catalog.get_by_alternate_identifier("xyzzy:00000001")
     assert revision == sample_revision_two
 
+@pytest.mark.usefixtures("sample_revision", "referenced_revision")
+def test_memory_catalog_returns_latest_by_file_set_identifier(
+    sample_revision, referenced_revision
+) -> None:
+    catalog = MemoryCatalog()
+    catalog.add(sample_revision)
+    catalog.add(referenced_revision)
+
+    revisions = catalog.find_by_file_set("00000000-0000-0000-0000-000000001001")
+    assert sample_revision in revisions
+    assert referenced_revision in revisions
+
 @pytest.mark.usefixtures("sample_revision", "sample_revision_two")
 def test_memory_catalog_gets_revisions(
     sample_revision, sample_revision_two
@@ -188,6 +200,23 @@ def test_catalog_returns_none_when_no_alternate_identifier_matches(db_session, s
 
     revision = catalog.get_by_alternate_identifier("xyzzy:00000001.404")
     assert revision is None
+
+@pytest.mark.usefixtures("db_session", "sample_revision", "referenced_revision")
+def test_catalog_returns_latest_for_alternate_identifier(
+    db_session, sample_revision, referenced_revision
+) -> None:
+    catalog = SqlalchemyCatalog(db_session)
+    with db_session.begin():
+        catalog.add(sample_revision)
+        db_session.commit()
+
+    with db_session.begin():
+        catalog.add(referenced_revision)
+        db_session.commit()
+
+    revisions = catalog.find_by_file_set("00000000-0000-0000-0000-000000001001")
+    assert sample_revision in revisions
+    assert referenced_revision in revisions
 
 @pytest.mark.usefixtures("db_session", "sample_revision", "sample_revision_two")
 def test_catalog_gets_revisions(

--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -5,7 +5,7 @@ import pytest
 
 from dor.adapters.converter import converter
 from dor.builders.parts import UseFunction
-from dor.service_layer.catalog_service import summarize, get_file_sets, index_by_file_set
+from dor.service_layer.catalog_service import summarize, get_file_sets, index_by_file_set, summarize_by_file_set
 from dor.domain.models import Revision
 from dor.providers.models import (
     Agent, AlternateIdentifier, FileMetadata, FileReference, PackageResource,
@@ -142,3 +142,42 @@ def test_catalog_index_by_file_set(sample_revision, referenced_revision):
     }
 
     assert expected_mapping == mapping
+
+
+@pytest.mark.usefixtures("sample_revision", "referenced_revision")
+def test_catalog_search_with_file_sets(sample_revision, referenced_revision):
+    file_set_identifier = "00000000-0000-0000-0000-000000001001"
+    summaries = summarize_by_file_set([sample_revision, referenced_revision], uuid.UUID(file_set_identifier))
+
+    referenced_file_set_identifier = AlternateIdentifier(
+        type=UseFunction.copy_of.value,
+        id=file_set_identifier
+    )
+    expected_summaries = [
+        converter.unstructure(dict(
+            identifier=sample_revision.identifier,
+            revision_number=sample_revision.revision_number,
+            created_at=sample_revision.created_at,
+            alternate_identifiers=sample_revision.alternate_identifiers,
+            common_metadata=sample_revision.common_metadata,
+            file_sets=[
+                str(resource.id)
+                for resource in sample_revision.package_resources
+                if str(resource.id) == file_set_identifier or referenced_file_set_identifier in resource.alternate_identifiers
+            ]
+        )),
+        converter.unstructure(dict(
+            identifier=referenced_revision.identifier,
+            revision_number=referenced_revision.revision_number,
+            created_at=referenced_revision.created_at,
+            alternate_identifiers=referenced_revision.alternate_identifiers,
+            common_metadata=referenced_revision.common_metadata,
+            file_sets=[
+                str(resource.id)
+                for resource in referenced_revision.package_resources
+                if resource.id == file_set_identifier or referenced_file_set_identifier in resource.alternate_identifiers
+            ]
+        )),
+    ]
+
+    assert expected_summaries == summaries

--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -5,7 +5,7 @@ import pytest
 
 from dor.adapters.converter import converter
 from dor.builders.parts import UseFunction
-from dor.service_layer.catalog_service import summarize, get_file_sets, index_by_file_set, summarize_by_file_set
+from dor.service_layer.catalog_service import summarize, get_file_sets, index_by_file_set, summarize_with_file_sets
 from dor.domain.models import Revision
 from dor.providers.models import (
     Agent, AlternateIdentifier, FileMetadata, FileReference, PackageResource,
@@ -147,7 +147,7 @@ def test_catalog_index_by_file_set(sample_revision, referenced_revision):
 @pytest.mark.usefixtures("sample_revision", "referenced_revision")
 def test_catalog_search_with_file_sets(sample_revision, referenced_revision):
     file_set_identifier = "00000000-0000-0000-0000-000000001001"
-    summaries = summarize_by_file_set([sample_revision, referenced_revision], uuid.UUID(file_set_identifier))
+    summaries = summarize_with_file_sets([sample_revision, referenced_revision], uuid.UUID(file_set_identifier))
 
     referenced_file_set_identifier = AlternateIdentifier(
         type=UseFunction.copy_of.value,

--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -11,6 +11,7 @@ from dor.providers.models import (
     PreservationEvent, StructMap, StructMapItem, StructMapType
 )
 
+
 @pytest.mark.usefixtures("sample_revision")
 def test_catalog_generates_summary(sample_revision):
     expected_summary = converter.unstructure(dict(
@@ -23,6 +24,7 @@ def test_catalog_generates_summary(sample_revision):
     summary = summarize(sample_revision)
     assert expected_summary == summary
 
+
 @pytest.mark.usefixtures("sample_revision")
 def test_catalog_lists_file_sets(sample_revision):
     file_sets = get_file_sets(sample_revision)
@@ -33,12 +35,13 @@ def test_catalog_lists_file_sets(sample_revision):
 
     assert file_sets == expected_file_sets
 
+
 def test_catalog_has_empty_file_sets():
     no_file_sets_revision = Revision(
         identifier=uuid.UUID("00000000-0000-0000-0000-000000000001"),
         revision_number=1,
         created_at=datetime(2025, 2, 5, 12, 0, 0, 0, tzinfo=UTC),
-        alternate_identifiers=["xyzzy:00000001"], 
+        alternate_identifiers=["xyzzy:00000001"],
         common_metadata={
             "@schema": "urn:umich.edu:dor:schema:common",
             "title": "Discussion also Republican owner hot already itself.",
@@ -54,7 +57,7 @@ def test_catalog_has_empty_file_sets():
                 id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
                 type="Monograph",
                 root=True,
-                alternate_identifier=AlternateIdentifier(id="xyzzy:00000001", type="DLXS"),
+                alternate_identifiers=[AlternateIdentifier(id="xyzzy:00000001", type="DLXS")],
                 events=[
                     PreservationEvent(
                         identifier="abdcb901-721a-4be0-a981-14f514236633",

--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -160,11 +160,11 @@ def test_catalog_search_with_file_sets(sample_revision, referenced_revision):
             created_at=sample_revision.created_at,
             alternate_identifiers=sample_revision.alternate_identifiers,
             common_metadata=sample_revision.common_metadata,
-            file_sets=[
+            file_set_identifier=[
                 str(resource.id)
                 for resource in sample_revision.package_resources
                 if str(resource.id) == file_set_identifier or referenced_file_set_identifier in resource.alternate_identifiers
-            ]
+            ][0]
         )),
         converter.unstructure(dict(
             identifier=referenced_revision.identifier,
@@ -172,11 +172,11 @@ def test_catalog_search_with_file_sets(sample_revision, referenced_revision):
             created_at=referenced_revision.created_at,
             alternate_identifiers=referenced_revision.alternate_identifiers,
             common_metadata=referenced_revision.common_metadata,
-            file_sets=[
+            file_set_identifier=[
                 str(resource.id)
                 for resource in referenced_revision.package_resources
                 if resource.id == file_set_identifier or referenced_file_set_identifier in resource.alternate_identifiers
-            ]
+            ][0]
         )),
     ]
 

--- a/tests/test_descriptor_file_parser.py
+++ b/tests/test_descriptor_file_parser.py
@@ -56,7 +56,7 @@ class DescriptorFileParserTest(TestCase):
 
         expected_identifier = [AlternateIdentifier(type="DLXS", id="xyzzy:00000001")]
 
-        self.assertEqual(parser.get_alternate_identifier(), expected_identifier)
+        self.assertEqual(parser.get_alternate_identifiers(), expected_identifier)
 
     def test_parser_can_get_preservation_event_paths(self):
         parser = DescriptorFileParser(self.descriptor_path)

--- a/tests/test_descriptor_file_parser.py
+++ b/tests/test_descriptor_file_parser.py
@@ -54,7 +54,7 @@ class DescriptorFileParserTest(TestCase):
     def test_parser_can_get_alternate_identifier(self):
         parser = DescriptorFileParser(self.descriptor_path)
 
-        expected_identifier = AlternateIdentifier(type="DLXS", id="xyzzy:00000001")
+        expected_identifier = [AlternateIdentifier(type="DLXS", id="xyzzy:00000001")]
 
         self.assertEqual(parser.get_alternate_identifier(), expected_identifier)
 

--- a/tests/test_descriptor_generator.py
+++ b/tests/test_descriptor_generator.py
@@ -95,9 +95,9 @@ def sample_resources():
         PackageResource(
             id=uuid.UUID("00000000-0000-0000-0000-000000001001"),
             type="File Set",
-            alternate_identifiers=AlternateIdentifier(
+            alternate_identifiers=[AlternateIdentifier(
                 id="xyzzy:00000001:00000001", type="DLXS"
-            ),
+            )],
             events=[
                 PreservationEvent(
                     identifier="fe4c76e5-dbf1-4934-97fb-52ef5a68f073",

--- a/tests/test_descriptor_generator.py
+++ b/tests/test_descriptor_generator.py
@@ -26,7 +26,7 @@ def sample_resources():
             id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
             type="Monograph",
             root=True,
-            alternate_identifier=AlternateIdentifier(id="xyzzy:00000001", type="DLXS"),
+            alternate_identifiers=[AlternateIdentifier(id="xyzzy:00000001", type="DLXS")],
             events=[
                 PreservationEvent(
                     identifier="abdcb901-721a-4be0-a981-14f514236633",
@@ -95,7 +95,7 @@ def sample_resources():
         PackageResource(
             id=uuid.UUID("00000000-0000-0000-0000-000000001001"),
             type="File Set",
-            alternate_identifier=AlternateIdentifier(
+            alternate_identifiers=AlternateIdentifier(
                 id="xyzzy:00000001:00000001", type="DLXS"
             ),
             events=[
@@ -188,6 +188,7 @@ def sample_resources():
         ),
     ]
 
+
 def test_generator_can_create_descriptor_files(sample_resources):
     file_provider = FilesystemFileProvider()
     package_path = Path("./tests/output/test_descriptor_generator")
@@ -196,8 +197,11 @@ def test_generator_can_create_descriptor_files(sample_resources):
     generator = DescriptorGenerator(package_path=package_path, resources=sample_resources)
     generator.write_files()
 
-    assert (package_path / "00000000-0000-0000-0000-000000000001" / "descriptor" / "00000000-0000-0000-0000-000000000001.monograph.mets2.xml" ).exists()
-    assert (package_path / "00000000-0000-0000-0000-000000001001" / "descriptor" / "00000000-0000-0000-0000-000000001001.file_set.mets2.xml" ).exists()
+    assert (package_path / "00000000-0000-0000-0000-000000000001" / "descriptor" /
+            "00000000-0000-0000-0000-000000000001.monograph.mets2.xml").exists()
+    assert (package_path / "00000000-0000-0000-0000-000000001001" / "descriptor" /
+            "00000000-0000-0000-0000-000000001001.file_set.mets2.xml").exists()
+
 
 def test_generator_can_return_entries(sample_resources):
     file_provider = FilesystemFileProvider()

--- a/tests/test_package_resource_merger.py
+++ b/tests/test_package_resource_merger.py
@@ -24,7 +24,7 @@ def current() -> list[PackageResource]:
         PackageResource(
             id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
             type="Monograph",
-            alternate_identifier=AlternateIdentifier(id="xyzzy:00000001", type="DLXS"),
+            alternate_identifiers=[AlternateIdentifier(id="xyzzy:00000001", type="DLXS")],
             events=[
                 PreservationEvent(
                     identifier="23b04e8b-f7fd-4331-a3bb-0157f9a057d6",
@@ -105,7 +105,7 @@ def incoming() -> list[PackageResource]:
         PackageResource(
             id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
             type="Monograph",
-            alternate_identifier=AlternateIdentifier(id="xyzzy:00000001", type="DLXS"),
+            alternate_identifiers=[AlternateIdentifier(id="xyzzy:00000001", type="DLXS")],
             events=[
                 PreservationEvent(
                     identifier="94032aff-e1a9-4c1b-8066-3e153f57df67",
@@ -186,7 +186,7 @@ def partial() -> list[PackageResource]:
         PackageResource(
             id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
             type="Monograph",
-            alternate_identifier=AlternateIdentifier(id="xyzzy:00000001", type="DLXS"),
+            alternate_identifiers=[AlternateIdentifier(id="xyzzy:00000001", type="DLXS")],
             events=[
                 PreservationEvent(
                     identifier="5c6a593d-afb8-49da-a91a-c12c91cfb4e8",
@@ -251,7 +251,8 @@ def test_merging_complete_resources(current: list[PackageResource], incoming: li
     results = merger.merge_changes()
 
     assert results[0].metadata_files == incoming[0].metadata_files
-    assert results[0].events == ( current[0].events + incoming[0].events )
+    assert results[0].events == (current[0].events + incoming[0].events)
+
 
 def test_merging_partial_resources(current: list[PackageResource], partial: list[PackageResource]):
     merger = PackageResourcesMerger(current=current, incoming=partial)

--- a/tests/test_resource_provider.py
+++ b/tests/test_resource_provider.py
@@ -45,7 +45,7 @@ class ResourceProviderTest(TestCase):
             id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
             type="Monograph",
             root=True,
-            alternate_identifier=AlternateIdentifier(id="xyzzy:00000001", type="DLXS"),
+            alternate_identifier=[AlternateIdentifier(id="xyzzy:00000001", type="DLXS")],
             events=[
                 PreservationEvent(
                     identifier="8c1e311a-e477-409f-aed3-d0ddbcfbc3fa",
@@ -125,9 +125,9 @@ class ResourceProviderTest(TestCase):
         expected_resource = PackageResource(
             id=uuid.UUID("00000000-0000-0000-0000-000000001001"),
             type="File Set",
-            alternate_identifier=AlternateIdentifier(
+            alternate_identifier=[AlternateIdentifier(
                 id="xyzzy:00000001:00000001", type="DLXS"
-            ),
+            )],
             events=[
                 PreservationEvent(
                     identifier="e88b7591-31db-4e32-98dc-b35f94c662cd",

--- a/tests/test_resource_provider.py
+++ b/tests/test_resource_provider.py
@@ -45,7 +45,7 @@ class ResourceProviderTest(TestCase):
             id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
             type="Monograph",
             root=True,
-            alternate_identifier=[AlternateIdentifier(id="xyzzy:00000001", type="DLXS")],
+            alternate_identifiers=[AlternateIdentifier(id="xyzzy:00000001", type="DLXS")],
             events=[
                 PreservationEvent(
                     identifier="8c1e311a-e477-409f-aed3-d0ddbcfbc3fa",
@@ -125,7 +125,7 @@ class ResourceProviderTest(TestCase):
         expected_resource = PackageResource(
             id=uuid.UUID("00000000-0000-0000-0000-000000001001"),
             type="File Set",
-            alternate_identifier=[AlternateIdentifier(
+            alternate_identifiers=[AlternateIdentifier(
                 id="xyzzy:00000001:00000001", type="DLXS"
             )],
             events=[


### PR DESCRIPTION
PR resolves [DOR-69](https://mlit.atlassian.net/browse/DOR-69) and adds `catalog.find_by_file_set(requested_identifier)`.

A revision matches if

- we match `PackageResource.identifier` in `revision.package_resources`
- we find an alternate identifier in the `PackageResource` with a type `function:version`

The catalog api was extended with `/catalog/revisions/index/{file_set_identifier}` returning the structure defined in #83 

Tasks:

- [x] allow `PackageResource.alternate_identifier` to be a list
- [x] add `find_by_file_set` to the catalog adapters
- [x] update scalar references to `PackageResource.alternate_identifier`
- [x] configure a `GIN` index on the `CurrentRevision.package_resources` column
- [x] update the `catalog` entrypoint
- [x] decide whether `function:version` is its final name and add to `UseFunction`
   - [ ] `function:references`?
   - [ ] `function:is-version-of`? (mirroring Dublin Core relations)
   - [x] `function:is-copy-of`? (very literal)
- [x] decide whether a singular-formatted `alternate_identifier` returning a list is too much an XML/XPath smell
