### PR TITLE
Change name of queue specified in `Worker`

### DIFF
--- a/bin/generic-worker.py
+++ b/bin/generic-worker.py
@@ -6,5 +6,5 @@ from dor.providers.filesets import redis
 # it would be specific to fileset processing or overall orchestration; we
 # simply have not made any decisions on the dispatch or job-type boundaries.
 
-w = Worker(['fileset.basic-image'], connection=redis)
+w = Worker(['fileset'], connection=redis)
 w.work()


### PR DESCRIPTION
This PR changes the name of the queue the `Worker` is listening to to match the new queue name "fileset" in `dor/providers/filesets.py`.

https://github.com/mlibrary/dor-py/blob/22439e3f29a073c51cbb81035178e9ffbb93d2f5/dor/providers/filesets.py#L32