### PR TITLE
Set up CLI app for installation as package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ requirements.txt
 output/
 .DS_Store
 
+dist/
+
 tests/test_payload
 tests/test_storage/
 tests/test_descriptor_generator/

--- a/dor/builders/file_set.py
+++ b/dor/builders/file_set.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from faker import Faker
 from PIL import Image, ImageDraw
 
-from dor.settings import S, text_font, template_env
+from dor.settings import S, template_env
 
 from .parts import (
     UseFormat,
@@ -43,11 +43,11 @@ def build_image(use, seq, version):
 
     message = f"Page v{version}.{seq}"
 
-    _, _, w, h = d.textbbox((0, 0), message, font=text_font)
+    _, _, w, h = d.textbbox((0, 0), message, font=S.text_font)
     d.text(
         ((IMAGE_WIDTH - w) / 2, (IMAGE_HEIGHT - h) / 2),
         message,
-        font=text_font,
+        font=S.text_font,
         fill=text_color,
     )
 

--- a/dor/cli/main.py
+++ b/dor/cli/main.py
@@ -2,10 +2,16 @@ import typer
 import dor.cli.samples as samples
 import dor.cli.repo as repo
 
-app = typer.Typer()
+app = typer.Typer(no_args_is_help=True)
 app.add_typer(samples.app, name="samples")
 app.add_typer(repo.app, name="repo")
 
 
-if __name__ == "__main__":  # pragma: no cover
-    app()
+@app.callback()
+def banner():
+    """
+    DOR Utilities
+
+    The various DOR command line utilities are packaged as a command suite.
+    Use --help to explore the subcommands.
+    """

--- a/dor/cli/repo.py
+++ b/dor/cli/repo.py
@@ -3,7 +3,7 @@ from dor.domain.events import PackageSubmitted
 from dor.service_layer.framework import create_repo, workframe
 from utils.minter import minter
 
-app = typer.Typer()
+app = typer.Typer(no_args_is_help=True)
 
 
 @app.command()

--- a/dor/cli/samples.py
+++ b/dor/cli/samples.py
@@ -10,7 +10,7 @@ from dor.builders.resource import build_resource
 import sys
 import datetime
 
-app = typer.Typer()
+app = typer.Typer(no_args_is_help=True)
 
 """
 ## About the Sample Generator

--- a/dor/settings.py
+++ b/dor/settings.py
@@ -1,8 +1,27 @@
 from dataclasses import dataclass, field
 from enum import Enum
 import pathlib
+from importlib import resources
 
 from PIL import ImageFont
+
+RESOURCE_ROOT = resources.files("etc")
+FONT_ROOT = RESOURCE_ROOT / "fonts"
+
+
+@dataclass
+class FontFile:
+    directory: str = "DepartureMono-1.420"
+    family: str = "DepartureMono"
+    variant: str = "Regular"
+    format: str = "woff2"
+    filename: str = f"{family}-{variant}.{format}"
+
+    _path: str = f"{directory}/{filename}"
+
+    def load(self, dpi: int = 72) -> ImageFont.FreeTypeFont:
+        with resources.as_file(FONT_ROOT / self._path) as file:
+            return ImageFont.truetype(file, dpi)
 
 
 class ActionChoices(str, Enum):
@@ -24,6 +43,7 @@ class Settings:
     total: int = 1
     output_pathname: str = None
     seed: int = -1
+    text_font: ImageFont.FreeTypeFont = FontFile().load()
 
     def update(self, **kw):
         for key, value in kw.items():
@@ -42,11 +62,4 @@ template_env = Environment(
         pathlib.Path(__file__).resolve().parent.parent.joinpath("templates")
     ),
     autoescape=select_autoescape(),
-)
-
-text_font = ImageFont.truetype(
-    pathlib.Path(__file__)
-    .resolve()
-    .parent.parent.joinpath("etc/fonts/DepartureMono-1.420/DepartureMono-Regular.woff2"),
-    72,
 )

--- a/poetry.lock
+++ b/poetry.lock
@@ -1512,17 +1512,17 @@ full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart 
 
 [[package]]
 name = "typer"
-version = "0.12.5"
+version = "0.15.4"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typer-0.12.5-py3-none-any.whl", hash = "sha256:62fe4e471711b147e3365034133904df3e235698399bc4de2b36c8579298d52b"},
-    {file = "typer-0.12.5.tar.gz", hash = "sha256:f592f089bedcc8ec1b974125d64851029c3b1af145f04aca64d69410f0c9b722"},
+    {file = "typer-0.15.4-py3-none-any.whl", hash = "sha256:eb0651654dcdea706780c466cf06d8f174405a659ffff8f163cfbfee98c0e173"},
+    {file = "typer-0.15.4.tar.gz", hash = "sha256:89507b104f9b6a0730354f27c39fae5b63ccd0c95b1ce1f1a6ba0cfd329997c3"},
 ]
 
 [package.dependencies]
-click = ">=8.0.0"
+click = ">=8.0.0,<8.2"
 rich = ">=10.11.0"
 shellingham = ">=1.3.0"
 typing-extensions = ">=3.7.4.3"
@@ -1831,4 +1831,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "8d4cf75127cbc04e88f3237ab9b1f896869f061841f7656ff3fff5084440291f"
+content-hash = "0e41a8143d386d644f56dae2642a942945ebbe0e90bbbdf28e2c42122641d026"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 description = "DOR scripts"
 authors = ["Roger Espinosa <roger@umich.edu>"]
 readme = "README.md"
-packages = [{include = "dor"}]
+packages = [{include = "dor"}, {include = "gateway"}, {include = "utils"}]
+include = [{path = "etc", format = ["sdist", "wheel"]}]
 
 [tool.poetry.scripts]
 dor = "dor.cli.main:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ bagit = {version = "^1.9b2", allow-prereleases = true}
 faker = "^30.3.0"
 faker-biology = "^0.6.4"
 pillow = "^10.4.0"
-typer = "^0.12.5"
+typer = "^0.15.4"
 uuid6 = "^2024.7.10"
 python-ulid = "^2.7.0"
 jinja2 = "^3.1.4"


### PR DESCRIPTION
Fix up the CLI app to be able to run under poetry as well as be installed. There are two commits with messages detailing:

- The Typer-related changes to run either way and render help by default
- Packaging the additional modules and the etc directory so everything can be loaded