### PR TITLE
Set up command-or-event handling

### DIFF
--- a/dor/domain/commands.py
+++ b/dor/domain/commands.py
@@ -1,0 +1,5 @@
+from dataclasses import dataclass
+
+@dataclass
+class Command:
+    pass

--- a/dor/service_layer/framework.py
+++ b/dor/service_layer/framework.py
@@ -81,5 +81,5 @@ def workframe() -> Tuple[MemoryMessageBus, SqlalchemyUnitOfWork]:
 
     command_handlers: dict[Type[Command], Callable] = {}
 
-    message_bus = MemoryMessageBus(event_handlers=event_handlers, command_handlers=command_handlers)
+    message_bus = MemoryMessageBus(event_handlers=event_handlers, command_handlers=command_handlers, uow=uow)
     return (message_bus, uow)

--- a/dor/service_layer/framework.py
+++ b/dor/service_layer/framework.py
@@ -51,7 +51,7 @@ def workframe() -> Tuple[MemoryMessageBus, SqlalchemyUnitOfWork]:
         file_provider=file_provider
     )
 
-    handlers: dict[Type[Event], list[Callable]] = {
+    event_handlers: dict[Type[Event], list[Callable]] = {
         PackageSubmitted: [
             lambda event: record_workflow_event(event, uow),
             lambda event: receive_package(event, uow, translocator)
@@ -78,5 +78,8 @@ def workframe() -> Tuple[MemoryMessageBus, SqlalchemyUnitOfWork]:
             lambda event: record_workflow_event(event, uow)
         ]
     }
-    message_bus = MemoryMessageBus(handlers)
+
+    command_handlers: dict[Type[Command], Callable] = {}
+
+    message_bus = MemoryMessageBus(event_handlers=event_handlers, command_handlers=command_handlers)
     return (message_bus, uow)

--- a/dor/service_layer/message_bus/memory_message_bus.py
+++ b/dor/service_layer/message_bus/memory_message_bus.py
@@ -9,7 +9,7 @@ class MemoryMessageBus:
     def __init__(
         self,
         event_handlers: dict[Type[Event], list[Callable]],
-        command_handlers: dict[Type[Command], Callable] = {}
+        command_handlers: dict[Type[Command], Callable]
     ):
         # In-memory storage for event handlers
         self.event_handlers = event_handlers

--- a/dor/service_layer/message_bus/memory_message_bus.py
+++ b/dor/service_layer/message_bus/memory_message_bus.py
@@ -1,24 +1,33 @@
-from typing import Callable, Type
+from typing import Callable, Type, Union
+from dor.domain.commands import Command
 from dor.domain.events import Event
 from dor.service_layer.unit_of_work import AbstractUnitOfWork
 
+Message = Union[Command, Event]
 
 class MemoryMessageBus:
-    def __init__(self, handlers: dict[Type[Event], list[Callable]]):
+    def __init__(
+        self,
+        event_handlers: dict[Type[Event], list[Callable]],
+        command_handlers: dict[Type[Command], Callable] = {}
+    ):
         # In-memory storage for event handlers
-        self.event_handlers = handlers
+        self.event_handlers = event_handlers
+        self.command_handlers = command_handlers
 
     def register_event_handler(self, event_type: Type[Event], handler: Callable):
         if event_type not in self.event_handlers:
             self.event_handlers[event_type] = []
         self.event_handlers[event_type].append(handler)    
 
-    def handle(self, message, uow: AbstractUnitOfWork):
+    def handle(self, message: Message, uow: AbstractUnitOfWork):
         # Handles a message, which must be an event.
         if isinstance(message, Event):
             self._handle_event(message, uow)
+        elif isinstance(message, Command):
+            return self._handle_command(message, uow)
         else:
-            raise ValueError(f"Message of type {type(message)} is not a valid Event")
+            raise ValueError(f"Message of type {type(message)} is not a valid Command or Event")
 
     def _handle_event(self, event: Event, uow: AbstractUnitOfWork):
         # Handles an event by executing its registered handlers.
@@ -33,6 +42,14 @@ class MemoryMessageBus:
             another_event = uow.pop_event()
             if another_event:
                 queue.append(another_event)
+
+    def _handle_command(self, command: Command, uow: AbstractUnitOfWork):
+        try:
+            handler = self.command_handlers[type(command)]
+            return handler(command, uow)
+        except:
+            # TODO: log missing command handler
+            raise
               
 class NoHandlerForEventError(Exception):
-    pass             
+    pass

--- a/tests/features/fixtures/message_bus.py
+++ b/tests/features/fixtures/message_bus.py
@@ -36,7 +36,7 @@ def message_bus(unit_of_work: AbstractUnitOfWork) -> MemoryMessageBus:
         file_provider=FilesystemFileProvider()
     )
 
-    handlers: dict[Type[Event], list[Callable]] = {
+    event_handlers: dict[Type[Event], list[Callable]] = {
         PackageSubmitted: [
             lambda event: record_workflow_event(event, unit_of_work),
             lambda event: receive_package(event, unit_of_work, translocator)
@@ -68,5 +68,5 @@ def message_bus(unit_of_work: AbstractUnitOfWork) -> MemoryMessageBus:
             lambda event: record_workflow_event(event, unit_of_work),
         ]
     }
-    message_bus = MemoryMessageBus(handlers)
+    message_bus = MemoryMessageBus(event_handlers=event_handlers, command_handlers={})
     return message_bus

--- a/tests/features/fixtures/message_bus.py
+++ b/tests/features/fixtures/message_bus.py
@@ -68,5 +68,5 @@ def message_bus(unit_of_work: AbstractUnitOfWork) -> MemoryMessageBus:
             lambda event: record_workflow_event(event, unit_of_work),
         ]
     }
-    message_bus = MemoryMessageBus(event_handlers=event_handlers, command_handlers={})
+    message_bus = MemoryMessageBus(event_handlers=event_handlers, command_handlers={}, uow=unit_of_work)
     return message_bus

--- a/tests/features/steps/test_store_resource.py
+++ b/tests/features/steps/test_store_resource.py
@@ -34,7 +34,7 @@ def _(unit_of_work: AbstractUnitOfWork):
     u'the Collection Manager places the packaged resource in the incoming location',
     target_fixture="tracking_identifier"
 )
-def _(message_bus: MemoryMessageBus, unit_of_work: AbstractUnitOfWork):
+def _(message_bus: MemoryMessageBus):
     submission_id = "xyzzy-00000000-0000-0000-0000-000000000001-v1"
     tracking_identifier = str(uuid.uuid4())
 
@@ -42,7 +42,7 @@ def _(message_bus: MemoryMessageBus, unit_of_work: AbstractUnitOfWork):
         package_identifier=submission_id,
         tracking_identifier=tracking_identifier
     )
-    message_bus.handle(event, unit_of_work)
+    message_bus.handle(event)
     return tracking_identifier
 
 

--- a/tests/features/steps/test_update_resource.py
+++ b/tests/features/steps/test_update_resource.py
@@ -37,13 +37,13 @@ def _(unit_of_work: AbstractUnitOfWork, message_bus: MemoryMessageBus):
         package_identifier=submission_id,
         tracking_identifier=tracking_identifier
     )
-    message_bus.handle(event, unit_of_work)
+    message_bus.handle(event)
 
 
 @when('the Collection Manager places the packaged resource in the incoming location',
       target_fixture="tracking_identifier"
       )
-def _(message_bus: MemoryMessageBus, unit_of_work: AbstractUnitOfWork):
+def _(message_bus: MemoryMessageBus):
     """the Collection Manager places the packaged resource in the incoming location."""
     submission_id = "xyzzy-00000000-0000-0000-0000-000000000001-v1"
     tracking_identifier = "second-load"
@@ -52,7 +52,7 @@ def _(message_bus: MemoryMessageBus, unit_of_work: AbstractUnitOfWork):
         tracking_identifier=tracking_identifier,
         update_flag=True,
     )
-    message_bus.handle(event, unit_of_work)
+    message_bus.handle(event)
     return tracking_identifier
 
 
@@ -81,7 +81,7 @@ def test_updating_only_metadata_of_a_resource_for_immediate_release():
     "the Collection Manager places the packaged resource with the metadata in the incoming location",
     target_fixture="tracking_identifier",
 )
-def _(message_bus: MemoryMessageBus, unit_of_work: AbstractUnitOfWork):
+def _(message_bus: MemoryMessageBus):
     """the Collection Manager places the packaged resource with the metadata in the incoming location."""
     submission_id = "xyzzy-00000000-0000-0000-0000-000000000001-v2"
     tracking_identifier = "second-load"
@@ -91,5 +91,5 @@ def _(message_bus: MemoryMessageBus, unit_of_work: AbstractUnitOfWork):
         tracking_identifier=tracking_identifier,
         update_flag=True,
     )
-    message_bus.handle(event, unit_of_work)
+    message_bus.handle(event)
     return tracking_identifier

--- a/tests/test_memory_message_bus.py
+++ b/tests/test_memory_message_bus.py
@@ -39,10 +39,7 @@ def test_message_bus_command_returns_result() -> None:
     command_handlers: dict[type[Command], Callable] = {
         Echo: echo
     }
-    message_bus = MemoryMessageBus(
-        event_handlers={},
-        command_handlers=command_handlers
-    )
+    message_bus = MemoryMessageBus({}, command_handlers)
 
     value = message_bus.handle(Echo("hello"), uow)
 
@@ -64,7 +61,7 @@ def test_message_bus_can_handle_cascading_events() -> None:
         EventA: [respond_to_a],
         EventB: [respond_to_b],
     }
-    message_bus = MemoryMessageBus(event_handlers)
+    message_bus = MemoryMessageBus(event_handlers, {})
     
     message_bus.handle(EventA(id="1"), uow)
 
@@ -80,7 +77,7 @@ def test_message_bus_with_single_event() -> None:
     event_handlers: dict[type[Event], list[Callable]] = {
         EventA: [respond_to_a]
     }
-    message_bus = MemoryMessageBus(event_handlers)
+    message_bus = MemoryMessageBus(event_handlers, {})
     
     message_bus.handle(EventA(id="1"), uow)
 
@@ -89,7 +86,7 @@ def test_message_bus_with_single_event() -> None:
 def test_message_bus_throws_error_for_event_with_no_handlers() -> None:
     uow = UnitOfWork(FakeRepositoryGateway())
     event_handlers: dict[type[Event], list[Callable]] = {}
-    message_bus = MemoryMessageBus(event_handlers)
+    message_bus = MemoryMessageBus(event_handlers, {})
 
     with pytest.raises(NoHandlerForEventError):
         message_bus.handle(EventA(id="1"), uow)
@@ -107,7 +104,7 @@ def test_message_bus_can_handle_multiple_handlers_for_same_event() -> None:
     event_handlers: dict[type[Event], list[Callable]] = {
         EventA: [first_handler, second_handler]
     }
-    message_bus = MemoryMessageBus(event_handlers)
+    message_bus = MemoryMessageBus(event_handlers, {})
 
     message_bus.handle(EventA(id="1"), uow)
 


### PR DESCRIPTION
- Add base Command type
- Add a Message union type for Command | Event
- Convert all preexisting instantiations of MemoryMessageBus from "handlers" to "event handlers"
- Add command handlers dictionary to the message bus
- Return values from commands that are handled

We are not currently supporting commands "extending" the event queue, but should add that next, beyond simply returning the value.